### PR TITLE
reimplemented taotab to allow tabbing in an empty element

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -57,7 +57,7 @@ echo "Starting CKBuilder..."
 
 JAVA_ARGS=${ARGS// -t / } # Remove -t from arrgs
 
-VERSION="4.4.7 TAO-8"
+VERSION="4.4.7 TAO-9"
 REVISION=$(git rev-parse --verify --short HEAD)
 SEMVER_REGEX="^([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$"
 

--- a/plugins/taotab/plugin.js
+++ b/plugins/taotab/plugin.js
@@ -77,7 +77,14 @@ CKEDITOR.plugins.add('taotab', {
                     var newNode = findNewNode(getTextNodes(ranges[0].root.$), existingNodes);
                     focusNode = new CKEDITOR.dom.text(newNode);
 
-                    ranges = sel.getRanges();//get the new ranges from the current selection and set the cursor on the new text node:
+                    ranges = sel.getRanges();//get the new ranges from the current selection
+
+                    //address cross-browser issue (especially on EDGE): first, set the cursor in the text node (not on the edge)
+                    ranges[0].setStart(focusNode, tabSize-1);
+                    ranges[0].setEnd(focusNode, tabSize-1);
+                    sel.selectRanges([ranges[0]]);
+
+                    //finally, set the cursor at the end of the new text node
                     ranges[0].setStart(focusNode, tabSize);
                     ranges[0].setEnd(focusNode, tabSize);
                     sel.selectRanges([ranges[0]]);

--- a/plugins/taotab/plugin.js
+++ b/plugins/taotab/plugin.js
@@ -1,46 +1,97 @@
 CKEDITOR.plugins.add('taotab', {
-    onLoad: function(){
-        CKEDITOR.addCss('span.white-space-pre{white-space:pre}');
-    },
     init: function(editor) {
 
         /**
          * Build the tab string by concatenating spaces
-         * @param {Number} num
+         * @param {Number} size - the number of whitespaces for the tab
          * @returns {string}
          */
-        function buildSpacedTab(num){
+        function buildSpacedTab(size){
             var i, tabStr = '';
-            num = parseInt(num || 4, 10);//default is 4 spaces
-            for(i = 0; i< num; i++){
+            size = parseInt(size || 4, 10);//default is 4 spaces
+            for(i = 0; i< size; i++){
                 tabStr += String.fromCharCode(160);
             }
             return tabStr;
         }
 
+
+        /**
+         * Get all text nodes that are children of the given
+         * @param {HTMLElement} rootNode - the root node from which the search should start
+         * @returns {Array}
+         */
+        function getTextNodes(rootNode){
+            var textNodes = [];
+            for (var i = 0; i < rootNode.childNodes.length; i++) {
+                var curNode = rootNode.childNodes[i];
+                if (curNode.nodeType === Node.TEXT_NODE) {
+                    textNodes.push(curNode);
+                } else if(curNode.nodeType === Node.ELEMENT_NODE){
+                    textNodes = textNodes.concat(getTextNodes(curNode));
+                }
+            }
+            return textNodes;
+        }
+
+        /**
+         * Compare 2 arrays of HTMLElement and find the first extra one
+         * @param {Array} newNodes - the new list of nodes where we want to search for the new one
+         * @param {Array} existingNodes - the existing list of nodes
+         * @returns {HTMLElement}
+         */
+        function findNewNode(newNodes, existingNodes){
+            var i;
+            for(i = 0; i < newNodes.length; i++){
+                if(!existingNodes[i]){
+                    return newNodes[i];
+                }else if(!newNodes[i].isEqualNode(existingNodes[i])){
+                    return newNodes[i];
+                }
+            }
+        }
+
         editor.addCommand('insertTab', {
             exec: function(editor) {
+
+                //the default tab is 4 whitespaces:
+                var tabSize = 4;
 
                 //get selection info
                 var sel = editor.getSelection();
                 var ranges = sel.getRanges();
-                var caretPosition = ranges[0].startOffset;
 
                 //it is important to use the native selection node as the one provided by ck is somewhat buggy at times
                 var focusNode = new CKEDITOR.dom.text(sel._.cache.nativeSel.focusNode);
 
                 //replace text node, this technique is prefered to insertHtml because the latter will create a new text node and the caret position will be lost!
-                var position = caretPosition;
                 var text = focusNode.getText();
-                if(text === null){
-                    return;//todo fix this: temporarily skip the situation where the focus in on an empty node
-                }
-                focusNode.setText([text.slice(0, position), buildSpacedTab(), text.slice(position)].join(''));
 
-                //set the cursor at the end of the insertion
-                ranges[0].setStart(focusNode, caretPosition+4);
-                ranges[0].setEnd(focusNode, caretPosition+4);
-                sel.selectRanges([ranges[0]]);
+                if(text === null){
+
+                    //record the existing nodes for future references
+                    var existingNodes = getTextNodes(ranges[0].root.$);
+                    editor.insertHtml(buildSpacedTab(tabSize));
+
+                    //find the new text node that has just been added and select it
+                    var newNode = findNewNode(getTextNodes(ranges[0].root.$), existingNodes);
+                    focusNode = new CKEDITOR.dom.text(newNode);
+
+                    ranges = sel.getRanges();//get the new ranges from the current selection and set the cursor on the new text node:
+                    ranges[0].setStart(focusNode, tabSize);
+                    ranges[0].setEnd(focusNode, tabSize);
+                    sel.selectRanges([ranges[0]]);
+                }else{
+
+                    //get current caret position within the node
+                    var caretPosition = ranges[0].startOffset;
+                    focusNode.setText([text.slice(0, caretPosition), buildSpacedTab(tabSize), text.slice(caretPosition)].join(''));
+
+                    //set the cursor at the end of the insertion
+                    ranges[0].setStart(focusNode, caretPosition + tabSize);
+                    ranges[0].setEnd(focusNode, caretPosition + tabSize);
+                    sel.selectRanges([ranges[0]]);
+                }
             }
         });
 

--- a/plugins/taotab/plugin.js
+++ b/plugins/taotab/plugin.js
@@ -23,14 +23,13 @@ CKEDITOR.plugins.add('taotab', {
          */
         function getTextNodes(rootNode){
             var textNodes = [];
-            for (var i = 0; i < rootNode.childNodes.length; i++) {
-                var curNode = rootNode.childNodes[i];
+            rootNode.childNodes.forEach(function(curNode){
                 if (curNode.nodeType === Node.TEXT_NODE) {
                     textNodes.push(curNode);
                 } else if(curNode.nodeType === Node.ELEMENT_NODE){
                     textNodes = textNodes.concat(getTextNodes(curNode));
                 }
-            }
+            });
             return textNodes;
         }
 

--- a/plugins/taotab/plugin.js
+++ b/plugins/taotab/plugin.js
@@ -22,14 +22,15 @@ CKEDITOR.plugins.add('taotab', {
          * @returns {Array}
          */
         function getTextNodes(rootNode){
-            var textNodes = [];
-            rootNode.childNodes.forEach(function(curNode){
+            var i, textNodes = [];
+            for (i = 0; i < rootNode.childNodes.length; i++) {
+                var curNode = rootNode.childNodes[i];
                 if (curNode.nodeType === Node.TEXT_NODE) {
                     textNodes.push(curNode);
                 } else if(curNode.nodeType === Node.ELEMENT_NODE){
                     textNodes = textNodes.concat(getTextNodes(curNode));
                 }
-            });
+            }
             return textNodes;
         }
 

--- a/plugins/taountab/plugin.js
+++ b/plugins/taountab/plugin.js
@@ -1,9 +1,12 @@
 CKEDITOR.plugins.add('taountab', {
-    onLoad: function(){
-        CKEDITOR.addCss('span.white-space-pre{white-space:pre}');
-    },
     init: function(editor) {
 
+        /**
+         * Get the starting index of a pattern of successive whitespaces
+         * @param {String} selectedText - the string to look into
+         * @param {Number} spaceNum - number of successive spaces sequence to find
+         * @returns {Number}
+         */
         function getSuccessiveSpacesStartIndex(selectedText, spaceNum){
             var successive = 0;
             var startIndex = -1;
@@ -28,17 +31,20 @@ CKEDITOR.plugins.add('taountab', {
 
         editor.addCommand('removeTab', {
             exec: function(editor) {
+
                 var spaceNum = 4;
                 var sel = editor.getSelection();
                 var ranges = editor.getSelection().getRanges();
-                var caretPosition = ranges[0].startOffset;
-                var selectedText, startIndex, position;
+                var caretPosition, selectedText, startIndex, position;
+
                 //first, select a range of strings to verify if there are enough successive whitespaces, using the native selection is here more reliable than ckeditor's api
                 var focusNode = new CKEDITOR.dom.text(sel._.cache.nativeSel.focusNode);
                 var text = focusNode.getText();
+
                 if(text === null){
-                    return;//todo fix this: temporarily skip the situation where the focus in on an empty node
+                    return;//empty node so no tab to be removed
                 }
+                caretPosition = ranges[0].startOffset;
                 ranges[0].setStart(focusNode, Math.max(0, caretPosition - spaceNum));
                 ranges[0].setEnd(focusNode, Math.min(caretPosition + spaceNum, text.length));
                 sel.selectRanges([ranges[0]]);


### PR DESCRIPTION
Fixed the last issue remaining on TAO-6273 that prevent tabbing on an empty element.
I completely changed the approach and reimplemented almost entirely `plugins/taotab/plugin.js`
The idea is to programmatically find the new text node and reposition the caret in the right position so we don't rely on the ck api. Otherwise, the caret position will be kind of lost.