### PR TITLE
Fix BSA 183 - Add missing translations plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor4-dev",
-	"version": "4.14.3",
+	"version": "4.14.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor4-dev",
-	"version": "4.14.2",
+	"version": "4.14.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor4-dev",
-	"version": "4.14.2",
+	"version": "4.14.3",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor4-dev",
-	"version": "4.14.3",
+	"version": "4.14.2",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs": "0.4.3",

--- a/plugins/taohighlight/lang/de.js
+++ b/plugins/taohighlight/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanHighlight', 'de', {
+	button: 'Mathematischen Ausdruck einfügen',
+	title: 'Mathematischen Ausdruck einfügen'
+} );

--- a/plugins/taohighlight/lang/de.js
+++ b/plugins/taohighlight/lang/de.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'spanHighlight', 'de', {
-	button: 'Mathematischen Ausdruck einfügen',
-	title: 'Mathematischen Ausdruck einfügen'
+	button: 'Hervorhebung',
+	title: 'Hervorhebung'
 } );

--- a/plugins/taohighlight/lang/en.js
+++ b/plugins/taohighlight/lang/en.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanHighlight', 'en', {
+	button: 'Highlight',
+	title: 'Highlight'
+} );

--- a/plugins/taohighlight/lang/fr.js
+++ b/plugins/taohighlight/lang/fr.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'spanHighlight', 'fr', {
-	button: 'Insérer une expression mathémat',
-	title: 'Insérer une expression mathémat'
+	button: 'Surligner',
+	title: 'Surligner'
 } );

--- a/plugins/taohighlight/lang/fr.js
+++ b/plugins/taohighlight/lang/fr.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanHighlight', 'fr', {
+	button: 'Insérer une expression mathémat',
+	title: 'Insérer une expression mathémat'
+} );

--- a/plugins/taohighlight/lang/nl.js
+++ b/plugins/taohighlight/lang/nl.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanHighlight', 'nl', {
+	button: 'Wiskundige uitdrukking invoegen',
+	title: 'Wiskundige uitdrukking invoegen'
+} );

--- a/plugins/taohighlight/lang/nl.js
+++ b/plugins/taohighlight/lang/nl.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'spanHighlight', 'nl', {
-	button: 'Wiskundige uitdrukking invoegen',
-	title: 'Wiskundige uitdrukking invoegen'
+	button: 'Hoogtepunt',
+	title: 'Hoogtepunt'
 } );

--- a/plugins/taohighlight/plugin.js
+++ b/plugins/taohighlight/plugin.js
@@ -1,4 +1,5 @@
 CKEDITOR.plugins.add('taohighlight', {
+	lang: 'de,en,fr,nl', // %REMOVE_LINE_CORE%
     init : function(editor){
 		'use strict';
 
@@ -23,7 +24,7 @@ CKEDITOR.plugins.add('taohighlight', {
         }));
 
         editor.ui.addButton('TaoHighlight', {
-            label : 'Highlight',
+            label : editor.lang[commandName].button,
             command : commandName,
             icon : this.path + 'images/taohighlight.png'
         });

--- a/plugins/taomediamanager/lang/de.js
+++ b/plugins/taomediamanager/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertMedia', 'de', {
+	button: 'Mathematischen Ausdruck einfügen',
+	title: 'Mathematischen Ausdruck einfügen'
+} );

--- a/plugins/taomediamanager/lang/de.js
+++ b/plugins/taomediamanager/lang/de.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertMedia', 'de', {
-	button: 'Mathematischen Ausdruck einfügen',
-	title: 'Mathematischen Ausdruck einfügen'
+	button: 'Medien einfügen',
+	title: 'Medien einfügen'
 } );

--- a/plugins/taomediamanager/lang/en.js
+++ b/plugins/taomediamanager/lang/en.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertMedia', 'en', {
+	button: 'Insert Media',
+	title: 'Insert Media'
+} );

--- a/plugins/taomediamanager/lang/fr.js
+++ b/plugins/taomediamanager/lang/fr.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertMedia', 'fr', {
-	button: 'Insérer une expression mathémat',
-	title: 'Insérer une expression mathémat'
+	button: 'Insérer un média',
+	title: 'Insérer un média'
 } );

--- a/plugins/taomediamanager/lang/fr.js
+++ b/plugins/taomediamanager/lang/fr.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertMedia', 'fr', {
+	button: 'Insérer une expression mathémat',
+	title: 'Insérer une expression mathémat'
+} );

--- a/plugins/taomediamanager/lang/nl.js
+++ b/plugins/taomediamanager/lang/nl.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertMedia', 'nl', {
+	button: 'Wiskundige uitdrukking invoegen',
+	title: 'Wiskundige uitdrukking invoegen'
+} );

--- a/plugins/taomediamanager/lang/nl.js
+++ b/plugins/taomediamanager/lang/nl.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertMedia', 'nl', {
-	button: 'Wiskundige uitdrukking invoegen',
-	title: 'Wiskundige uitdrukking invoegen'
+	button: 'Invoegmedia',
+	title: 'Invoegmedia'
 } );

--- a/plugins/taomediamanager/plugin.js
+++ b/plugins/taomediamanager/plugin.js
@@ -5,6 +5,7 @@
 CKEDITOR.plugins.add('taomediamanager', {
     // The plugin initialization logic goes inside this method.
     // http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.pluginDefinition.html#init
+	lang: 'de,en,fr,nl', // %REMOVE_LINE_CORE%
     init: function (editor) {
         // Define an editor command that inserts a taomediamanager.
         // http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.editor.html#addCommand
@@ -37,7 +38,7 @@ CKEDITOR.plugins.add('taomediamanager', {
         // http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.ui.html#addButton
         editor.ui.addButton('TaoMediaManager', {
             // Toolbar button tooltip.
-            label: 'Insert Media',
+            label: editor.lang.insertMedia.button,
             // Reference to the plugin command name.
             command: 'insertMedia',
             // Button's icon file path.

--- a/plugins/taoqtiprintedvariable/lang/de.js
+++ b/plugins/taoqtiprintedvariable/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'de', {
+	button: 'Mathematischen Ausdruck einfügen',
+	title: 'Mathematischen Ausdruck einfügen'
+} );

--- a/plugins/taoqtiprintedvariable/lang/de.js
+++ b/plugins/taoqtiprintedvariable/lang/de.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'de', {
-	button: 'Mathematischen Ausdruck einfügen',
-	title: 'Mathematischen Ausdruck einfügen'
+	button: 'Gedruckte Variable einfügen',
+	title: 'Gedruckte Variable einfügen'
 } );

--- a/plugins/taoqtiprintedvariable/lang/en.js
+++ b/plugins/taoqtiprintedvariable/lang/en.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'en', {
+	button: 'Insert Printed Variable',
+	title: 'Insert Printed Variable'
+} );

--- a/plugins/taoqtiprintedvariable/lang/fr.js
+++ b/plugins/taoqtiprintedvariable/lang/fr.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'fr', {
-	button: 'Insérer une expression mathémat',
-	title: 'Insérer une expression mathémat'
+	button: 'Insérer la variable imprimée',
+	title: 'Insérer la variable imprimée'
 } );

--- a/plugins/taoqtiprintedvariable/lang/fr.js
+++ b/plugins/taoqtiprintedvariable/lang/fr.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'fr', {
+	button: 'Insérer une expression mathémat',
+	title: 'Insérer une expression mathémat'
+} );

--- a/plugins/taoqtiprintedvariable/lang/nl.js
+++ b/plugins/taoqtiprintedvariable/lang/nl.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'nl', {
+	button: 'Wiskundige uitdrukking invoegen',
+	title: 'Wiskundige uitdrukking invoegen'
+} );

--- a/plugins/taoqtiprintedvariable/lang/nl.js
+++ b/plugins/taoqtiprintedvariable/lang/nl.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertQtiPrintedVariable', 'nl', {
-	button: 'Wiskundige uitdrukking invoegen',
-	title: 'Wiskundige uitdrukking invoegen'
+	button: 'Bedrukte Variabele invoegen',
+	title: 'Bedrukte Variabele invoegen'
 } );

--- a/plugins/taoqtiprintedvariable/plugin.js
+++ b/plugins/taoqtiprintedvariable/plugin.js
@@ -1,4 +1,5 @@
 CKEDITOR.plugins.add('taoqtiprintedvariable', {
+	lang: 'de,en,fr,nl', // %REMOVE_LINE_CORE%
     init: function(editor) {
 
         editor.addCommand('insertQtiPrintedVariable', {

--- a/plugins/taotab/lang/de.js
+++ b/plugins/taotab/lang/de.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'de', {
+CKEDITOR.plugins.setLang( 'insertTab', 'de', {
 	button: 'Medien einfügen',
 	title: 'Medien einfügen'
 } );

--- a/plugins/taotab/lang/de.js
+++ b/plugins/taotab/lang/de.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertTab', 'de', {
-	button: 'Medien einfügen',
-	title: 'Medien einfügen'
+	button: 'Registerkarte einfügen',
+	title: 'Registerkarte einfügen'
 } );

--- a/plugins/taotab/lang/de.js
+++ b/plugins/taotab/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'de', {
+	button: 'Medien einfügen',
+	title: 'Medien einfügen'
+} );

--- a/plugins/taotab/lang/en.js
+++ b/plugins/taotab/lang/en.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'en', {
-	button: 'Insert Media',
-	title: 'Insert Media'
+CKEDITOR.plugins.setLang( 'insertTab', 'en', {
+	button: 'Insert Tab',
+	title: 'Insert Tab'
 } );

--- a/plugins/taotab/lang/en.js
+++ b/plugins/taotab/lang/en.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'en', {
+	button: 'Insert Media',
+	title: 'Insert Media'
+} );

--- a/plugins/taotab/lang/fr.js
+++ b/plugins/taotab/lang/fr.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'fr', {
+CKEDITOR.plugins.setLang( 'insertTab', 'fr', {
 	button: 'Insérer un média',
 	title: 'Insérer un média'
 } );

--- a/plugins/taotab/lang/fr.js
+++ b/plugins/taotab/lang/fr.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertTab', 'fr', {
-	button: 'Insérer un média',
-	title: 'Insérer un média'
+	button: 'Insérer une tabulation',
+	title: 'Insérer une tabulation'
 } );

--- a/plugins/taotab/lang/fr.js
+++ b/plugins/taotab/lang/fr.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'fr', {
+	button: 'Insérer un média',
+	title: 'Insérer un média'
+} );

--- a/plugins/taotab/lang/nl.js
+++ b/plugins/taotab/lang/nl.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'nl', {
+CKEDITOR.plugins.setLang( 'insertTab', 'nl', {
 	button: 'Invoegmedia',
 	title: 'Invoegmedia'
 } );

--- a/plugins/taotab/lang/nl.js
+++ b/plugins/taotab/lang/nl.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'insertTab', 'nl', {
-	button: 'Invoegmedia',
-	title: 'Invoegmedia'
+	button: 'Tab invoegen',
+	title: 'Tab invoegen'
 } );

--- a/plugins/taotab/lang/nl.js
+++ b/plugins/taotab/lang/nl.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'nl', {
+	button: 'Invoegmedia',
+	title: 'Invoegmedia'
+} );

--- a/plugins/taotab/plugin.js
+++ b/plugins/taotab/plugin.js
@@ -1,4 +1,5 @@
 CKEDITOR.plugins.add('taotab', {
+	lang: 'de,en,fr,nl', // %REMOVE_LINE_CORE%
     init: function(editor) {
 
         /**
@@ -103,7 +104,7 @@ CKEDITOR.plugins.add('taotab', {
         });
 
         editor.ui.addButton('TaoTab', {
-            label: 'Insert Tab',
+            label: editor.lang.insertTab.button,
             command: 'insertTab',
             icon: this.path + 'images/taotab.png'
         });

--- a/plugins/taounderline/lang/de.js
+++ b/plugins/taounderline/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanUnderline', 'de', {
+	button: 'Unterstreichen',
+	title: 'Unterstreichen'
+} );

--- a/plugins/taounderline/lang/en.js
+++ b/plugins/taounderline/lang/en.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanUnderline', 'en', {
+	button: 'Underline',
+	title: 'Underline'
+} );

--- a/plugins/taounderline/lang/fr.js
+++ b/plugins/taounderline/lang/fr.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanUnderline', 'fr', {
+	button: 'Souligner',
+	title: 'Souligner'
+} );

--- a/plugins/taounderline/lang/nl.js
+++ b/plugins/taounderline/lang/nl.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'spanUnderline', 'nl', {
+	button: 'Onderstreep',
+	title: 'Onderstreep'
+} );

--- a/plugins/taounderline/plugin.js
+++ b/plugins/taounderline/plugin.js
@@ -1,4 +1,5 @@
 CKEDITOR.plugins.add('taounderline', {
+	lang: 'de,en,fr,nl', // %REMOVE_LINE_CORE%
     init : function(editor){
 
         var commandName = 'spanUnderline',

--- a/plugins/taounderline/plugin.js
+++ b/plugins/taounderline/plugin.js
@@ -31,7 +31,7 @@ CKEDITOR.plugins.add('taounderline', {
         }));
 
         editor.ui.addButton('TaoUnderline', {
-            label : 'Underline',
+            label : editor.lang[commandName].button,
             command : commandName,
             icon : this.path + 'images/taounderline.png'
         });

--- a/plugins/taountab/lang/de.js
+++ b/plugins/taountab/lang/de.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'removeTab', 'de', {
-	button: 'Medien einfügen',
-	title: 'Medien einfügen'
+	button: 'Tab entfernen',
+	title: 'Tab entfernen'
 } );

--- a/plugins/taountab/lang/de.js
+++ b/plugins/taountab/lang/de.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'de', {
+CKEDITOR.plugins.setLang( 'removeTab', 'de', {
 	button: 'Medien einfügen',
 	title: 'Medien einfügen'
 } );

--- a/plugins/taountab/lang/de.js
+++ b/plugins/taountab/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'de', {
+	button: 'Medien einfügen',
+	title: 'Medien einfügen'
+} );

--- a/plugins/taountab/lang/en.js
+++ b/plugins/taountab/lang/en.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'en', {
-	button: 'Insert Media',
-	title: 'Insert Media'
+CKEDITOR.plugins.setLang( 'removeTab', 'en', {
+	button: 'Remove Tab',
+	title: 'Remove Tab'
 } );

--- a/plugins/taountab/lang/en.js
+++ b/plugins/taountab/lang/en.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'en', {
+	button: 'Insert Media',
+	title: 'Insert Media'
+} );

--- a/plugins/taountab/lang/fr.js
+++ b/plugins/taountab/lang/fr.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'fr', {
+CKEDITOR.plugins.setLang( 'removeTab', 'fr', {
 	button: 'Insérer un média',
 	title: 'Insérer un média'
 } );

--- a/plugins/taountab/lang/fr.js
+++ b/plugins/taountab/lang/fr.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'removeTab', 'fr', {
-	button: 'Insérer un média',
-	title: 'Insérer un média'
+	button: 'Retirer une tabulation',
+	title: 'Retirer une tabulation'
 } );

--- a/plugins/taountab/lang/fr.js
+++ b/plugins/taountab/lang/fr.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'fr', {
+	button: 'Insérer un média',
+	title: 'Insérer un média'
+} );

--- a/plugins/taountab/lang/nl.js
+++ b/plugins/taountab/lang/nl.js
@@ -1,4 +1,4 @@
 CKEDITOR.plugins.setLang( 'removeTab', 'nl', {
-	button: 'Invoegmedia',
-	title: 'Invoegmedia'
+	button: 'Tabblad verwijderen',
+	title: 'Tabblad verwijderen'
 } );

--- a/plugins/taountab/lang/nl.js
+++ b/plugins/taountab/lang/nl.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'insertQtiMedia', 'nl', {
+CKEDITOR.plugins.setLang( 'removeTab', 'nl', {
 	button: 'Invoegmedia',
 	title: 'Invoegmedia'
 } );

--- a/plugins/taountab/lang/nl.js
+++ b/plugins/taountab/lang/nl.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'insertQtiMedia', 'nl', {
+	button: 'Invoegmedia',
+	title: 'Invoegmedia'
+} );

--- a/plugins/taountab/plugin.js
+++ b/plugins/taountab/plugin.js
@@ -1,4 +1,5 @@
 CKEDITOR.plugins.add('taountab', {
+	lang: 'de,en,fr,nl', // %REMOVE_LINE_CORE%
     init: function(editor) {
 
         /**
@@ -72,7 +73,7 @@ CKEDITOR.plugins.add('taountab', {
         });
 
         editor.ui.addButton('TaoUnTab', {
-            label: 'Remove Tab',
+            label: editor.lang.removeTab.button,
             command: 'removeTab',
             icon: this.path + 'images/taountab.png'
         });


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BSA-183

**Description**

This PR is to allow dynamic translations of CKEditor based on selected language by the user

**AC**

- Translate `CKeditor` keys (`Insert Tab` and `Remove Tab`) in NL - DE - FR languages

**Note**

For other languages, I create this tech debt issue https://oat-sa.atlassian.net/browse/TAO-10422