### PR TITLE
Fix UNO 444  - Broken layers in DEMO when background tasks menu opened 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor4-dev",
-	"version": "4.14.2",
+	"version": "4.14.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ckeditor4-dev",
-	"version": "4.14.2",
+	"version": "4.14.3",
 	"description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
 	"devDependencies": {
 		"benderjs": "0.4.3",

--- a/skins/tao/editor.css
+++ b/skins/tao/editor.css
@@ -67,8 +67,8 @@ Usage:
     box-sizing: content-box;
     position: static;
     transition: none;
-	position: relative;
-	z-index: 0;
+    position: relative;
+    z-index: 0;
 }
 
 /* Reset for elements and their children. */

--- a/skins/tao/editor.css
+++ b/skins/tao/editor.css
@@ -67,6 +67,8 @@ Usage:
     box-sizing: content-box;
     position: static;
     transition: none;
+	position: relative;
+	z-index: 0;
 }
 
 /* Reset for elements and their children. */


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/UNO-444

**Description**

There're some issues with layers when the browser window resolution set to the smaller size e.g. 900x700 and the item has a property type set to Text - Long - HTML editor: the list of background tasks partially covered by edit item properties form. Reproduced only in `UDIR` demo environment.

**Preconditions**

Class property type is set to Text - Long - HTML editor.

**Steps to reproduce**

- Navigate to the Items tab
- Narrow the browser window 
- Open the Background tasks menu

**Actual result**

The opened Background tasks menu is partially covered by 'Kommentar' field in edit item properties filed.

**Expected result**

The opened Background tasks menu covers the edit item properties form.

![imagen](https://user-images.githubusercontent.com/34692207/91433018-e4209100-e862-11ea-9310-55fb6070c129.png)
