### PR TITLE
fix: alter table translations for jp

### DIFF
--- a/lang/ja.js
+++ b/lang/ja.js
@@ -97,7 +97,6 @@ CKEDITOR.lang[ 'ja' ] = {
 		invalidHtmlLength: '入力された "%1" 項目の値は、HTMLの大きさ(px または %)が正しいものである/ないに関わらず、正の値である必要があります。',
 		invalidInlineStyle: '入力されたインラインスタイルの値は、"名前 : 値" のフォーマットのセットで、複数の場合はセミコロンで区切られている形式である必要があります。',
 		cssLengthTooltip: 'ピクセル数もしくはCSSにセットできる数値を入力してください。(px,%,in,cm,mm,em,ex,pt,or pc)',
-		invalidRows: '行数は 0 より大きい値にしてください。',
 
 		// Put the voice-only part of the label in the span.
 		unavailable: '%1<span class="cke_accessibility">, 利用不可能</span>',

--- a/plugins/table/lang/ja.js
+++ b/plugins/table/lang/ja.js
@@ -56,7 +56,7 @@ CKEDITOR.plugins.setLang( 'table', 'ja', {
 	invalidCellSpacing: 'セル間余白は数値で入力してください。',
 	invalidCols: '列数は0より大きな数値を入力してください。',
 	invalidHeight: '高さは数値で入力してください。',
-	invalidRows: '行数は0より大きな数値を入力してください。',
+	invalidRows: '行数は0より大きい値にしてください。',
 	invalidWidth: '幅は数値で入力してください。',
 	menu: '表のプロパティ',
 	row: {


### PR DESCRIPTION
Use correct token to translate invalid row