### PR TITLE
fix: disable all buttons when inside ruby

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -68,9 +68,9 @@ CKEDITOR.plugins.add('taofurigana', {
     /**
 		 * Make sure that the current selection is not already inside a furigana/ruby
 		 * @param {Node} node
-		 * @returns {CKEDITOR.dom.node|null}
+		 * @returns {boolean}
 		 */
-		function isInFigurana(node) {
+		function isInFugirana(node) {
 			return node.getAscendant('ruby') !== null;
 		}
 		/**
@@ -105,7 +105,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		 * @returns {boolean}
 		 */
 		function canInsert(selection) {
-			return !isSelectionEmpty(selection) && selection.getRanges()[0] && !isInFigurana(selection.getRanges()[0].startContainer) ;
+			return !isSelectionEmpty(selection) && selection.getRanges()[0] && !isInFugirana(selection.getRanges()[0].startContainer) ;
 		}
 		/**
 		 * @param {Node} startNode
@@ -172,7 +172,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				if (furiganaCanBeCreated(editor)) {
 					command.setState(CKEDITOR.TRISTATE_OFF);
 					setButtonsState(CKEDITOR.TRISTATE_OFF);
-				} else if (selection.getRanges()[0] && isInFigurana(range.startContainer)) {
+				} else if (selection.getRanges()[0] && isInFugirana(range.startContainer)) {
 					if (deleteRubyIfNoRt(range.startContainer, false, selection)) {
 						command.setState(CKEDITOR.TRISTATE_DISABLED);
 						setButtonsState(CKEDITOR.TRISTATE_OFF);
@@ -200,7 +200,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					rtElement,
 					range,
 					emptyElement;
-				if (isInFigurana(startNode)) {
+				if (isInFugirana(startNode)) {
 					rubyElement = startNode.getAscendant('ruby');
 					rbElement = rubyElement.find('rb');
 					rtElement = rubyElement.find('rt');

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.add('taofurigana', {
 
 		var commandName = 'rubyFurigana';
 		var containsTag;
+		var otherButtons = [];
+		var combos = [];
 		/**
 		 * @param {CKEDITOR.dom.selection} selection
 		 * @returns {CKEDITOR.dom.element}
@@ -144,18 +146,46 @@ CKEDITOR.plugins.add('taofurigana', {
 			var command = editor.getCommand(commandName);
       var selection = editor.getSelection();
 			var range = selection.getRanges()[0];
+			if (!otherButtons.length) {
+				editor.toolbar.forEach(function (element) {
+					if (element.items && element.items.length) {
+						element.items.forEach(function (item) {
+								if (item.command && item.command !== commandName) {
+									otherButtons.push(item.command);
+								} else if(!item.command && typeof item.setState !== "undefined") {
+									combos.push(item);
+								}
+						});
+					}
+				});
+			}
+			function setButtonsState(state) {
+				otherButtons.forEach(function(button) {
+					editor.getCommand(button).setState(state);
+				});
+				combos.forEach(function(combo) {
+					combo.setState(state);
+				});
+			}
 
 			if (command) {
 				if (furiganaCanBeCreated(editor)) {
 					command.setState(CKEDITOR.TRISTATE_OFF);
+					setButtonsState(CKEDITOR.TRISTATE_OFF);
 				} else if (selection.getRanges()[0] && isInFigurana(range.startContainer)) {
 					if (deleteRubyIfNoRt(range.startContainer, false, selection)) {
 						command.setState(CKEDITOR.TRISTATE_DISABLED);
+						setButtonsState(CKEDITOR.TRISTATE_OFF);
 					} else {
 						command.setState(CKEDITOR.TRISTATE_ON);
+						setTimeout(function() {
+							setButtonsState(CKEDITOR.TRISTATE_DISABLED);
+						}, 150);
+						
 					}
 				} else {
 					command.setState(CKEDITOR.TRISTATE_DISABLED);
+					setButtonsState(CKEDITOR.TRISTATE_OFF);
 				}
 			}
 		}

--- a/plugins/taotooltip/plugin.js
+++ b/plugins/taotooltip/plugin.js
@@ -24,7 +24,7 @@ CKEDITOR.plugins.add('taotooltip', {
 			var selection = editor.getSelection();
 			var nativeSelection = selection.getNative();
 
-			return nativeSelection !== null && (canInsert(nativeSelection) || isWrappable(nativeSelection)) && !isInFigurana(selection.getRanges()[0].startContainer);
+			return nativeSelection !== null && (canInsert(nativeSelection) || isWrappable(nativeSelection)) && !isInFugirana(selection.getRanges()[0].startContainer);
 		}
 
 	    /**
@@ -129,9 +129,9 @@ CKEDITOR.plugins.add('taotooltip', {
     /**
 		 * Make sure that the current selection is not already inside a furigana/ruby
 		 * @param {Node} node
-		 * @returns {CKEDITOR.dom.node|null}
+		 * @returns {boolean}
 		 */
-		function isInFigurana(node) {
+		function isInFugirana(node) {
 			return node.getAscendant('ruby') !== null;
 		}
 	    /**

--- a/plugins/taotooltip/plugin.js
+++ b/plugins/taotooltip/plugin.js
@@ -24,7 +24,7 @@ CKEDITOR.plugins.add('taotooltip', {
 			var selection = editor.getSelection();
 			var nativeSelection = selection.getNative();
 
-			return nativeSelection !== null && (canInsert(nativeSelection) || isWrappable(nativeSelection));
+			return nativeSelection !== null && (canInsert(nativeSelection) || isWrappable(nativeSelection)) && !isInFigurana(selection.getRanges()[0].startContainer);
 		}
 
 	    /**
@@ -32,7 +32,7 @@ CKEDITOR.plugins.add('taotooltip', {
 	     * @returns {boolean}
 	     */
 		function canInsert(selection) {
-			var range = selection.getRangeAt(0)
+			var range = selection.getRangeAt(0);
 			return isSelectionEmpty(selection) && !isInTooltip(selection.getRangeAt(range.startContainer));
 		}
 
@@ -126,7 +126,14 @@ CKEDITOR.plugins.add('taotooltip', {
 					&& el.$.dataset.qtiClass === '_tooltip';
 			});
 		}
-
+    /**
+		 * Make sure that the current selection is not already inside a furigana/ruby
+		 * @param {Node} node
+		 * @returns {CKEDITOR.dom.node|null}
+		 */
+		function isInFigurana(node) {
+			return node.getAscendant('ruby') !== null;
+		}
 	    /**
 	     * @param {CKEDITOR.dom.selection} selection
 	     * @returns {CKEDITOR.dom.element}


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2828

To prevent broken markup - disable all buttons, when cursor is into ruby tag

How to test:
- create ruby tag
- put cursor inside
- all buttons should be disabled

![image](https://user-images.githubusercontent.com/25976342/212094045-742e0f64-eabb-453a-adb8-db1611c326c7.png)
