### PR TITLE
Fix/pisa25 364/fix sourcedialog textarea size

### DIFF
--- a/plugins/sourcedialog/dialogs/sourcedialog.js
+++ b/plugins/sourcedialog/dialogs/sourcedialog.js
@@ -68,7 +68,8 @@ CKEDITOR.dialog.add( 'sourcedialog', function( editor ) {
 				id: 'data',
 				dir: 'ltr',
 				inputStyle: 'cursor:auto;' +
-					'width:' + width + 'px;' +
+					'width:100%;' + //rely on parent size
+					'maxwidth:unset' + //remove any maxwidth constraints
 					'height:' + height + 'px;' +
 					'tab-size:4;' +
 					'text-align:left;',

--- a/plugins/sourcedialog/dialogs/sourcedialog.js
+++ b/plugins/sourcedialog/dialogs/sourcedialog.js
@@ -69,7 +69,8 @@ CKEDITOR.dialog.add( 'sourcedialog', function( editor ) {
 				dir: 'ltr',
 				inputStyle: 'cursor:auto;' +
 					'width:100%;' + //rely on parent size
-					'maxwidth:unset' + //remove any maxwidth constraints
+					'min-width:' + width + 'px;' + //set appropriate min-width
+					'max-width:unset;' + //remove any maxwidth constraints
 					'height:' + height + 'px;' +
 					'tab-size:4;' +
 					'text-align:left;',


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/PISA25-364

### Description

Setups `min-width` and `max-width` for SourceDialog textarea. Otherwise the values are overriden in tao

### How to test

Built ckeditor added to tao-core-shared-liv, can be checked on kitchen