### PR TITLE
fix: forcely update handlebars version to 4.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4661,7 +4661,7 @@
 			"integrity": "sha1-EMakDFN8G2xlZIxrft8AGKAPw/A=",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.3.0"
+				"handlebars": "^4.7.7"
 			}
 		},
 		"grunt-jscs": {
@@ -5912,7 +5912,7 @@
 				"escodegen": "1.7.x",
 				"esprima": "2.6.x",
 				"fileset": "0.2.x",
-				"handlebars": "^4.3.0",
+				"handlebars": "^4.7.7",
 				"js-yaml": "3.x",
 				"mkdirp": "0.5.x",
 				"nopt": "3.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"JSV": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-			"integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-			"dev": true
-		},
 		"abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -48,7 +42,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"ansi-gray": {
 			"version": "0.1.1",
@@ -4666,28 +4661,7 @@
 			"integrity": "sha1-EMakDFN8G2xlZIxrft8AGKAPw/A=",
 			"dev": true,
 			"requires": {
-				"handlebars": "~1.0.12"
-			},
-			"dependencies": {
-				"handlebars": {
-					"version": "1.0.12",
-					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
-					"integrity": "sha1-GMbTRAw16RsZs/9YK5FRq0mF1Pw=",
-					"dev": true,
-					"requires": {
-						"optimist": "~0.3",
-						"uglify-js": "~2.3"
-					}
-				},
-				"optimist": {
-					"version": "0.3.7",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-					"dev": true,
-					"requires": {
-						"wordwrap": "~0.0.2"
-					}
-				}
+				"handlebars": "^4.3.0"
 			}
 		},
 		"grunt-jscs": {
@@ -5058,34 +5032,35 @@
 			}
 		},
 		"handlebars": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
-			"integrity": "sha1-f05Tf03WmShp1mwBt1BeujVhpdU=",
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
 			"dev": true,
 			"requires": {
-				"optimist": "^0.6.1",
-				"source-map": "^0.1.40",
-				"uglify-js": "~2.3"
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
-				"optimist": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-					"dev": true,
-					"requires": {
-						"minimist": "~0.0.1",
-						"wordwrap": "~0.0.2"
-					}
+				"minimist": {
+					"version": "1.2.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+					"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+					"dev": true
 				},
 				"source-map": {
-					"version": "0.1.43",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+					"dev": true
 				}
 			}
 		},
@@ -5928,16 +5903,16 @@
 			"dev": true
 		},
 		"istanbul": {
-			"version": "git://github.com/benderjs/istanbul.git#72abdd52b38deac7272afba931b970a7e8866997",
-			"from": "git://github.com/benderjs/istanbul.git",
+			"version": "git+ssh://git@github.com/benderjs/istanbul.git#72abdd52b38deac7272afba931b970a7e8866997",
 			"dev": true,
+			"from": "istanbul@git://github.com/benderjs/istanbul.git",
 			"requires": {
 				"abbrev": "1.0.x",
 				"async": "1.x",
 				"escodegen": "1.7.x",
 				"esprima": "2.6.x",
 				"fileset": "0.2.x",
-				"handlebars": "3.0.0",
+				"handlebars": "^4.3.0",
 				"js-yaml": "3.x",
 				"mkdirp": "0.5.x",
 				"nopt": "3.x",
@@ -6229,6 +6204,12 @@
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
 			}
+		},
+		"JSV": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+			"integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
+			"dev": true
 		},
 		"kind-of": {
 			"version": "3.2.2",
@@ -7412,6 +7393,12 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
 			"integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
 		"node-status-codes": {
@@ -9898,6 +9885,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+			"dev": true
+		},
 		"string-template": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -9923,12 +9916,6 @@
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
 			}
-		},
-		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-			"dev": true
 		},
 		"stringstream": {
 			"version": "0.0.6",
@@ -10580,35 +10567,11 @@
 			"optional": true
 		},
 		"uglify-js": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-			"integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
 			"dev": true,
-			"requires": {
-				"async": "~0.2.6",
-				"optimist": "~0.3.5",
-				"source-map": "~0.1.7"
-			},
-			"dependencies": {
-				"optimist": {
-					"version": "0.3.7",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-					"dev": true,
-					"requires": {
-						"wordwrap": "~0.0.2"
-					}
-				},
-				"source-map": {
-					"version": "0.1.43",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-					"dev": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
+			"optional": true
 		},
 		"uid": {
 			"version": "0.0.2",
@@ -11308,7 +11271,8 @@
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
 			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xmlbuilder": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
 		"lesshat": "^4.1.0",
 		"shelljs": "^0.8.2"
 	},
+	"overrides": {
+		"handlebars": "^4.3.0"
+	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"shelljs": "^0.8.2"
 	},
 	"overrides": {
-		"handlebars": "^4.3.0"
+		"handlebars": "^4.7.7"
 	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixing uglify-js vulnerability by updating handlebars version 
uglify-js is sub-dependency of grunt-githooks package, which is seemed even not used.

https://github.com/oat-sa/ckeditor-dev/security/dependabot/46
https://github.com/oat-sa/ckeditor-dev/security/dependabot/2

## Related to [ADF-1586](https://oat-sa.atlassian.net/browse/ADF-1586)

[ADF-1586]: https://oat-sa.atlassian.net/browse/ADF-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## How to test

Currently git commit hook is not used. Ideally it should run code check on each commit to hinder committing out-of-style changes