### PR TITLE
Fix/aut 3961/taofurigana ruby rt not focused

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -136,7 +136,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				}
 				editor.fire( 'unlockSnapshot' );
 				return true;
-			} 
+			}
 		}
 		/**
 		 * Change command state according to the current selection content
@@ -181,7 +181,7 @@ CKEDITOR.plugins.add('taofurigana', {
 						setTimeout(function() {
 							setButtonsState(CKEDITOR.TRISTATE_DISABLED);
 						}, 150);
-						
+
 					}
 				} else {
 					command.setState(CKEDITOR.TRISTATE_DISABLED);
@@ -206,7 +206,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					rtElement = rubyElement.find('rt');
 					if (deleteRubyIfNoRt(startNode, true)) {
 						refreshCommandState(editor);
-					} else if (rbElement.$.length && rtElement.$.length && startNode.getParent().$ === rtElement.$[0] && 
+					} else if (rbElement.$.length && rtElement.$.length && startNode.getParent().$ === rtElement.$[0] &&
 							startNode.$.nextSibling === null && curRange.endOffset + 1 >= startNode.$.length) {
 						// if in the end of rt text
 						// move cursor outside ruby element
@@ -239,7 +239,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 					// move cursor inside <rt>^</rt> Element
 					range = new CKEDITOR.dom.range(editor.document);
-					range.moveToElementEditablePosition(rtElement);
+					range.moveToElementEditablePosition(rtElement, true);
 					editor.getSelection().selectRanges([range]);
 					refreshCommandState(editor);
 


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/AUT-3961

Use with:
- https://github.com/oat-sa/tao-core-shared-libs-fe/pull/42
- https://github.com/oat-sa/tao-core/pull/4160

Deployed on: 

### Issue
In _Chrome,_ in Authoring add a ruby tag --> `<rt>` is not focused automatically, so author can't type his furigana. If you press "_arrow-right_" to move cursor, then it's focused.
Fine in _Firefox_.

Probably, the cause of the issue is not a change in our code, but a change of native browser behavior for `contenteditable` in newer versions.

Fixed by moving cursor position one symbol after: [ckeditor docs](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_range.html#method-moveToElementEditablePosition).

### TODO:
- [ ] test on Safari

### Other issues:
I'm pretty sure these issues existed before too (= always). Still, let's at least take a look.
- Placeholder `&nbsp;` (`<rt>&nbsp;</rt>`) is never removed, even after user enters his furigana, it stays in itemData
  - tried to use `CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE` instead, `<rt>` is fine then, but this sequence is _sometimes_ appended after ruby?
  - should we use `\200B` (zero-width-space) instead, or even trim it in item-runner?
  - can we somehow modify DOM and remove it on `blur` for example? If `taofurigana` was an inline widget with `downcast/upcast` converters, it would have been possible. But it's a native html tag, so not sure.
- If you remove this `&nbsp;` placeholder by pressing `Del/Backspace`, and don't enter any other text, you can no longer return and edit your ruby, even though it stays in the markup and itemData.
- Strange cursor position when typing (at the end of `<rb>`, away from where the actual typing inside `<rt>` happens): browser `contentediatble` issue, try in playground: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable : `<div contenteditable="true"><p><ruby><rb>とても長い言葉</rb><rt>&nbsp;</rt></ruby>で話す<ruby><rb>のわ楽しい</rb><rt>たのしい</rt></ruby>かもしれない</p></div>`. Check [ruby-align](https://developer.mozilla.org/en-US/docs/Web/CSS/ruby-align).