### PR TITLE
fix: handle empty ruby tags when user loses focus on editor

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -1,12 +1,13 @@
 CKEDITOR.plugins.add('taofurigana', {
 	lang: 'en', // %REMOVE_LINE_CORE%
-  init : function(editor){
+	init: function (editor) {
 		'use strict';
 
 		var commandName = 'rubyFurigana';
 		var containsTag;
 		var otherButtons = [];
 		var combos = [];
+
 		/**
 		 * @param {CKEDITOR.dom.selection} selection
 		 * @returns {CKEDITOR.dom.element}
@@ -16,6 +17,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				content = range.extractContents().$;
 			return new CKEDITOR.dom.element(content);
 		}
+
 		/**
 		 * @param {Node} node
 		 * @returns {boolean}
@@ -23,6 +25,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		function isTextNode(node) {
 			return node.nodeType === window.Node.TEXT_NODE;
 		}
+
 		/**
 		 * @param {Selection} selection
 		 * @returns {boolean}
@@ -30,6 +33,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		function isSelectionEmpty(selection) {
 			return selection && selection.isCollapsed();
 		}
+
 		/**
 		 * Return containing Element if current node is of type text
 		 * @param {Node} node
@@ -38,6 +42,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		function getContainerElement(node) {
 			return isTextNode(node) ? node.parentNode : node;
 		}
+
 		/**
 		 * We check for partially selected nodes
 		 * @param range
@@ -49,6 +54,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 			return start.isSameNode(end);
 		}
+
 		/**
 		 * Traverse a DOM tree to check if it contains a tags
 		 * @param {Node} rootNode
@@ -61,11 +67,12 @@ CKEDITOR.plugins.add('taofurigana', {
 				currentNode = childNodes[i];
 				if (!containsTag && !isTextNode(currentNode)) {
 					containsTag = true;
-          return;
+					return;
 				}
 			}
 		}
-    /**
+
+		/**
 		 * Make sure that the current selection is not already inside a furigana/ruby
 		 * @param {Node} node
 		 * @returns {boolean}
@@ -73,6 +80,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		function isInFugirana(node) {
 			return node.getAscendant('ruby') !== null;
 		}
+
 		/**
 		 * @param {Selection} selection
 		 * @returns {boolean}
@@ -84,12 +92,11 @@ CKEDITOR.plugins.add('taofurigana', {
 				containsTag = false;
 				searchTags(range.cloneContents());
 
-				return range.toString().trim() !== ''
-					&& isValidRange(range)
-					&& !containsTag;
+				return range.toString().trim() !== '' && isValidRange(range) && !containsTag;
 			}
 			return false;
 		}
+
 		/**
 		 * @param {CkEditor} editor - ckEditor instance
 		 */
@@ -97,7 +104,7 @@ CKEDITOR.plugins.add('taofurigana', {
 			var selection = editor.getSelection();
 			var nativeSelection = selection.getNative();
 
-			return nativeSelection !== null && canInsert(selection)&& isWrappable(nativeSelection);
+			return nativeSelection !== null && canInsert(selection) && isWrappable(nativeSelection);
 		}
 
 		/**
@@ -105,8 +112,9 @@ CKEDITOR.plugins.add('taofurigana', {
 		 * @returns {boolean}
 		 */
 		function canInsert(selection) {
-			return !isSelectionEmpty(selection) && selection.getRanges()[0] && !isInFugirana(selection.getRanges()[0].startContainer) ;
+			return !isSelectionEmpty(selection) && selection.getRanges()[0] && !isInFugirana(selection.getRanges()[0].startContainer);
 		}
+
 		/**
 		 * @param {Node} startNode
 		 * @param {Boolean} byClick
@@ -115,6 +123,9 @@ CKEDITOR.plugins.add('taofurigana', {
 		 */
 		function deleteRubyIfNoRt(startNode, byClick, selection) {
 			var rubyElement = startNode.getAscendant('ruby');
+			if (!rubyElement) {
+				return false;
+			}
 			var rbElement = rubyElement.find('rb');
 			var rtElement = rubyElement.find('rt');
 			var range;
@@ -123,9 +134,9 @@ CKEDITOR.plugins.add('taofurigana', {
 				// if rt is deleted
 				// of if click on toolbar button check that it is empty
 				// remove ruby, put base as text
-				editor.fire( 'saveSnapshot' );
-				editor.fire( 'lockSnapshot' );
-				rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
+				editor.fire('saveSnapshot');
+				editor.fire('lockSnapshot');
+				var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
 				rbHtml.replace(rubyElement);
 				if (!byClick) {
 					// select base text, to avoid know issue with delete key https://dev.ckeditor.com/ticket/9998
@@ -134,36 +145,38 @@ CKEDITOR.plugins.add('taofurigana', {
 					range.selectNodeContents(rbHtml);
 					selection.selectRanges([range]);
 				}
-				editor.fire( 'unlockSnapshot' );
+				editor.fire('unlockSnapshot');
 				return true;
 			}
 		}
+
 		/**
 		 * Change command state according to the current selection content
 		 * @param {CkEditor} editor - ckEditor instance
 		 */
 		function refreshCommandState(editor) {
 			var command = editor.getCommand(commandName);
-      var selection = editor.getSelection();
+			var selection = editor.getSelection();
 			var range = selection.getRanges()[0];
 			if (!otherButtons.length) {
 				editor.toolbar.forEach(function (element) {
 					if (element.items && element.items.length) {
 						element.items.forEach(function (item) {
-								if (item.command && item.command !== commandName) {
-									otherButtons.push(item.command);
-								} else if(!item.command && typeof item.setState !== "undefined") {
-									combos.push(item);
-								}
+							if (item.command && item.command !== commandName) {
+								otherButtons.push(item.command);
+							} else if (!item.command && typeof item.setState !== "undefined") {
+								combos.push(item);
+							}
 						});
 					}
 				});
 			}
+
 			function setButtonsState(state) {
-				otherButtons.forEach(function(button) {
+				otherButtons.forEach(function (button) {
 					editor.getCommand(button).setState(state);
 				});
-				combos.forEach(function(combo) {
+				combos.forEach(function (combo) {
 					combo.setState(state);
 				});
 			}
@@ -178,7 +191,7 @@ CKEDITOR.plugins.add('taofurigana', {
 						setButtonsState(CKEDITOR.TRISTATE_OFF);
 					} else {
 						command.setState(CKEDITOR.TRISTATE_ON);
-						setTimeout(function() {
+						setTimeout(function () {
 							setButtonsState(CKEDITOR.TRISTATE_DISABLED);
 						}, 150);
 
@@ -189,6 +202,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				}
 			}
 		}
+
 		// Create the command that can be used to apply the style.
 		editor.addCommand(commandName, {
 			exec: function (editor) {
@@ -208,7 +222,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					if (deleteRubyIfNoRt(startNode, true)) {
 						refreshCommandState(editor);
 					} else if (rbElement.$.length && rtElement.$.length && startNode.getParent().$ === rtElement.$[0] &&
-							startNode.$.nextSibling === null && curRange.endOffset + 1 >= startNode.$.length) {
+						startNode.$.nextSibling === null && curRange.endOffset + 1 >= startNode.$.length) {
 						// if in the end of rt text
 						// move cursor outside ruby element
 						range = new CKEDITOR.dom.range(editor.document);
@@ -225,8 +239,8 @@ CKEDITOR.plugins.add('taofurigana', {
 						}
 					}
 				} else if (furiganaCanBeCreated(editor)) {
-					editor.fire( 'saveSnapshot' );
-					editor.fire( 'lockSnapshot' );
+					editor.fire('saveSnapshot');
+					editor.fire('lockSnapshot');
 
 					rubyElement = new CKEDITOR.dom.element('ruby', editor.document);
 					rbElement = new CKEDITOR.dom.element('rb', editor.document);
@@ -237,7 +251,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					rubyElement.append(rtElement);
 
 					// create a temporary element for binding the cursor
-					anchor = new CKEDITOR.dom.element('span', editor.document);
+					var anchor = new CKEDITOR.dom.element('span', editor.document);
 					rtElement.append(anchor);
 					rtElement.appendHtml('&nbsp;');
 
@@ -254,7 +268,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					editor.getSelection().selectRanges([range]);
 					refreshCommandState(editor);
 
-					editor.fire( 'unlockSnapshot' );
+					editor.fire('unlockSnapshot');
 					// remove anchor
 					anchor.remove();
 				}
@@ -271,11 +285,31 @@ CKEDITOR.plugins.add('taofurigana', {
 			editable.attachListener(editable, 'keyup', function () {
 				refreshCommandState(editor);
 			});
+
+			editor.on('blur', function () {
+				// Get all ruby elements in the editor
+				var rubyElements = editor.document.find('ruby');
+				for (var i = 0; i < rubyElements.count(); i++) {
+					var ruby = rubyElements.getItem(i);
+					var rtElement = ruby.find('rt');
+
+					// Check if the rt element is empty
+					if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
+						var rbElement = ruby.find('rb');
+						if (rbElement.$.length) {
+							var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
+							rbHtml.replace(ruby);
+							editor.fire('unlockSnapshot');
+							refreshCommandState(editor);
+						}
+					}
+				}
+			});
 		});
 		editor.ui.addButton('TaoFurigana', {
-			label : editor.lang[commandName].button,
-			command : commandName,
-			icon : this.path + 'images/taofurigana.png'
+			label: editor.lang[commandName].button,
+			command: commandName,
+			icon: this.path + 'images/taofurigana.png'
 		});
 	}
 });

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -227,7 +227,7 @@ CKEDITOR.plugins.add('taofurigana', {
 						// move cursor outside ruby element
 						range = new CKEDITOR.dom.range(editor.document);
 						if (!rubyElement.$.nextSibling) {
-							range.moveToClosestEditablePosition(rubyElement, true)
+							range.moveToClosestEditablePosition(rubyElement, true);
 							selection.selectRanges([range]);
 							refreshCommandState(editor);
 						} else {
@@ -285,26 +285,39 @@ CKEDITOR.plugins.add('taofurigana', {
 			editable.attachListener(editable, 'keyup', function () {
 				refreshCommandState(editor);
 			});
+		});
+		editor.on('blur', function() {
+			// Get all ruby elements in the editor
+			var rubyElements = editor.document.find('ruby');
+			var modified = false;
 
-			editor.on('blur', function () {
-				// Get all ruby elements in the editor
-				var rubyElements = editor.document.find('ruby');
-				for (var i = 0; i < rubyElements.count(); i++) {
-					var ruby = rubyElements.getItem(i);
-					var rtElement = ruby.find('rt');
+			for (var i = 0; i < rubyElements.count(); i++) {
+				var ruby = rubyElements.getItem(i);
+				var rtElement = ruby.find('rt');
 
-					// Check if the rt element is empty
-					if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
-						var rbElement = ruby.find('rb');
-						if (rbElement.$.length) {
-							var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
-							rbHtml.replace(ruby);
-							editor.fire('unlockSnapshot');
-							refreshCommandState(editor);
-						}
+				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
+					var rbElement = ruby.find('rb');
+					if (rbElement.$.length) {
+						editor.fire('saveSnapshot');
+						editor.fire('lockSnapshot');
+
+						var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
+						rbHtml.replace(ruby);
+
+						editor.fire('unlockSnapshot');
+						modified = true;
 					}
 				}
-			});
+			}
+			//update editor textarea
+			if (modified) {
+				//
+				editor.updateElement();
+
+				editor.fire('change');
+
+				refreshCommandState(editor);
+			}
 		});
 		editor.ui.addButton('TaoFurigana', {
 			label: editor.lang[commandName].button,

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -285,38 +285,38 @@ CKEDITOR.plugins.add('taofurigana', {
 			editable.attachListener(editable, 'keyup', function () {
 				refreshCommandState(editor);
 			});
-		});
-		editor.on('blur', function() {
-			// Get all ruby elements in the editor
-			var rubyElements = editor.document.find('ruby');
-			var modified = false;
 
-			for (var i = 0; i < rubyElements.count(); i++) {
-				var ruby = rubyElements.getItem(i);
-				var rtElement = ruby.find('rt');
+			editor.on('blur', function() {
+				cleanupEmptyRubyTags();
+			});
 
-				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
-					var rbElement = ruby.find('rb');
-					if (rbElement.$.length) {
-						editor.fire('saveSnapshot');
-						editor.fire('lockSnapshot');
+			function cleanupEmptyRubyTags() {
+				var rubyElements = editor.document.find('ruby');
+				var modified = false;
 
-						var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
-						rbHtml.replace(ruby);
+				for (var i = 0; i < rubyElements.count(); i++) {
+					var ruby = rubyElements.getItem(i);
+					var rtElement = ruby.find('rt');
 
-						editor.fire('unlockSnapshot');
-						modified = true;
+					if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
+						var rbElement = ruby.find('rb');
+						if (rbElement.$.length) {
+							editor.fire('saveSnapshot');
+							editor.fire('lockSnapshot');
+
+							var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
+							rbHtml.replace(ruby);
+
+							editor.fire('unlockSnapshot');
+							modified = true;
+						}
 					}
 				}
-			}
-			//update editor textarea
-			if (modified) {
-				//
-				editor.updateElement();
 
-				editor.fire('change');
-
-				refreshCommandState(editor);
+				if (modified) {
+					editor.updateElement();
+					refreshCommandState(editor);
+				}
 			}
 		});
 		editor.ui.addButton('TaoFurigana', {

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -285,38 +285,38 @@ CKEDITOR.plugins.add('taofurigana', {
 			editable.attachListener(editable, 'keyup', function () {
 				refreshCommandState(editor);
 			});
+		});
+		editor.on('blur', function() {
+			// Get all ruby elements in the editor
+			var rubyElements = editor.document.find('ruby');
+			var modified = false;
 
-			editor.on('blur', function() {
-				cleanupEmptyRubyTags();
-			});
+			for (var i = 0; i < rubyElements.count(); i++) {
+				var ruby = rubyElements.getItem(i);
+				var rtElement = ruby.find('rt');
 
-			function cleanupEmptyRubyTags() {
-				var rubyElements = editor.document.find('ruby');
-				var modified = false;
+				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
+					var rbElement = ruby.find('rb');
+					if (rbElement.$.length) {
+						editor.fire('saveSnapshot');
+						editor.fire('lockSnapshot');
 
-				for (var i = 0; i < rubyElements.count(); i++) {
-					var ruby = rubyElements.getItem(i);
-					var rtElement = ruby.find('rt');
+						var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
+						rbHtml.replace(ruby);
 
-					if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
-						var rbElement = ruby.find('rb');
-						if (rbElement.$.length) {
-							editor.fire('saveSnapshot');
-							editor.fire('lockSnapshot');
-
-							var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
-							rbHtml.replace(ruby);
-
-							editor.fire('unlockSnapshot');
-							modified = true;
-						}
+						editor.fire('unlockSnapshot');
+						modified = true;
 					}
 				}
+			}
+			//update editor textarea
+			if (modified) {
+				//
+				editor.updateElement();
 
-				if (modified) {
-					editor.updateElement();
-					refreshCommandState(editor);
-				}
+				editor.fire('change');
+
+				refreshCommandState(editor);
 			}
 		});
 		editor.ui.addButton('TaoFurigana', {


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-283

## What's Changed

- Handle empty ruby tags when user loses `focus` on editor by using `blur` event in editor
  
## Dependencies PRs

- https://github.com/oat-sa/tao-core-shared-libs-fe/pull/48

## How to test
- Go to item authoring and add interaction for example `Choice`
- Add text to it, then select it and click "Insert Furigana" button from `CKEditor` toolbar
- Don't put any text in furigana prompt and simply move out from editor 
- Observe that empty furigana tag was removed and furigana toolbar button is not selected
- To verify it you can export item and see that there is no empty tag in qti xml
## Video

https://github.com/user-attachments/assets/46a2bc56-cfbc-468a-aacb-9a2708d09bc4

