### PR TITLE
fix: secure furigana plugin DOM handling and ensure proper snapshot management

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -136,16 +136,22 @@ CKEDITOR.plugins.add('taofurigana', {
 				// remove ruby, put base as text
 				editor.fire('saveSnapshot');
 				editor.fire('lockSnapshot');
-				var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
-				rbHtml.replace(rubyElement);
-				if (!byClick) {
-					// select base text, to avoid know issue with delete key https://dev.ckeditor.com/ticket/9998
-					// new text will be wrapped in <span style="font-size: 7px;">...</span>
-					range = new CKEDITOR.dom.range(editor.document);
-					range.selectNodeContents(rbHtml);
-					selection.selectRanges([range]);
+				try {
+					var rbNode = rbElement.count() ? rbElement.getItem(0) : null;
+					var baseText = rbNode ? rbNode.getText() : '';
+					var replacement = new CKEDITOR.dom.text(baseText, editor.document);
+					replacement.replace(rubyElement);
+					if (!byClick) {
+						// keep caret on the base text
+						range = new CKEDITOR.dom.range(editor.document);
+						range.selectNodeContents(replacement);
+						selection.selectRanges([range]);
+					}
+					editor.updateElement();
+					editor.fire('change');
+				} finally {
+					editor.fire('unlockSnapshot');
 				}
-				editor.fire('unlockSnapshot');
 				return true;
 			}
 		}
@@ -212,30 +218,37 @@ CKEDITOR.plugins.add('taofurigana', {
 					rubyElement,
 					rbElement,
 					rtElement,
-					range,
-					zeroWidthSpace,
-					emptyElement;
+					range;
 				if (isInFugirana(startNode)) {
 					rubyElement = startNode.getAscendant('ruby');
 					rbElement = rubyElement.find('rb');
-					rtElement = rubyElement.find('rt');
 					if (deleteRubyIfNoRt(startNode, true)) {
 						refreshCommandState(editor);
-					} else if (rbElement.$.length && rtElement.$.length && startNode.getParent().$ === rtElement.$[0] &&
-						startNode.$.nextSibling === null && curRange.endOffset + 1 >= startNode.$.length) {
-						// if in the end of rt text
-						// move cursor outside ruby element
-						range = new CKEDITOR.dom.range(editor.document);
-						if (!rubyElement.$.nextSibling) {
-							range.moveToClosestEditablePosition(rubyElement, true);
+					} else {
+						editor.fire('saveSnapshot');
+						editor.fire('lockSnapshot');
+
+						try {
+							var baseTextContent = '';
+							var rbNode = rbElement.getItem(0);
+							if (rbNode) {
+								baseTextContent = rbNode.getText();
+							}
+
+							var textNode = new CKEDITOR.dom.text(baseTextContent, editor.document);
+
+							textNode.replace(rubyElement);
+
+							range = new CKEDITOR.dom.range(editor.document);
+							range.setStartAfter(textNode);
+							range.collapse(true);
 							selection.selectRanges([range]);
+
+							editor.updateElement();
+							editor.fire('change');
 							refreshCommandState(editor);
-						} else {
-							emptyElement = new CKEDITOR.dom.text(CKEDITOR.dom.selection.FILLING_CHAR_SEQUENCE);
-							emptyElement.insertAfter(rubyElement);
-							range.moveToElementEditablePosition(emptyElement);
-							selection.selectRanges([range]);
-							refreshCommandState(editor);
+						} finally {
+							editor.fire('unlockSnapshot');
 						}
 					}
 				} else if (furiganaCanBeCreated(editor)) {
@@ -257,8 +270,11 @@ CKEDITOR.plugins.add('taofurigana', {
 
 					editor.insertElement(rubyElement);
 					// add a zero-width space for the better navigation in Chrome (version >= 128) to the next sibling
-					zeroWidthSpace = new CKEDITOR.dom.text('\u200b', editor.document);
-					rubyElement.append(zeroWidthSpace);
+					var nextSibling = rubyElement.getNext();
+					if (!nextSibling || (nextSibling.type === CKEDITOR.NODE_TEXT && nextSibling.getText().trim() === '')) {
+						var zeroWidthSpace = new CKEDITOR.dom.text('\u200b', editor.document);
+						zeroWidthSpace.insertAfter(rubyElement);
+					}
 
 					// move cursor inside the anchor
 					range = new CKEDITOR.dom.range(editor.document);


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-283

## What's Changed

- Empty ruby tags are now automatically removed when saved. If a user creates a ruby tag without furigana text, the tag is stripped out and only the base text remains.
- Ruby tags with actual furigana content (non-whitespace) are preserved exactly as entered.
- Ruby cleaning runs automatically whenever the user edits text, focuses/unfocuses the editor, saves, or closes the editor.
- Prompts with ruby tags now display with enough vertical spacing so furigana text is always clearly visible.
- Clicking the ruby button on text that already has a ruby tag now removes the entire tag, leaving just the base text.


## Dependencies PRs

-  https://github.com/oat-sa/extension-tao-itemqti/pull/2819


## How to test
- Go to items authoring 
- add item and input a text then select it and click ruby tag
- add ruby word and unfocus the editor
- focus it again select the word with ruby tag and click ruby button again it will remove the tag

## Video

https://github.com/user-attachments/assets/7211647b-f13d-41fa-8afe-39aa78cb2831




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Reliable caret placement after creating, deleting, or converting furigana, including on blur.
  - Prevents unintended zero-width spaces and empty text nodes.
  - More consistent state updates reduce glitches during edit flows.

- Refactor
  - Streamlined logic for creating, replacing, and updating furigana to improve stability.
  - Enhanced error safety and snapshot handling without changing public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->