### PR TITLE
fix: text tooling unblock for ruby tags

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -98,7 +98,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				return false;
 			}
 
-			return isInFugirana(node) && node.getAscendant('rt') !== null;
+			return isInFugirana(node) && node.getAscendant('rt', true) !== null;
 		}
 
 		/**

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -5,6 +5,9 @@ CKEDITOR.plugins.add('taofurigana', {
 
 		var commandName = 'rubyFurigana';
 		var containsTag;
+		var statelessButtons = [];
+		var statelessButtonsList = [
+			'bold', 'italic', 'strike', 'spanUnderline', 'subscript', 'superscript'];
 		var otherButtons = [];
 		var combos = [];
 
@@ -83,6 +86,19 @@ CKEDITOR.plugins.add('taofurigana', {
 			}
 
 			return node.getAscendant('ruby') !== null;
+		}
+
+		/**
+		 * Make sure that the current selection is already inside rt of furigana/ruby
+		 * @param {Node} node
+		 * @returns {boolean}
+		 */
+		function isInRtFugirana(node) {
+			if (!node) {
+				return false;
+			}
+
+			return isInFugirana(node) && node.getAscendant('rt') !== null;
 		}
 
 		/**
@@ -174,6 +190,9 @@ CKEDITOR.plugins.add('taofurigana', {
 						element.items.forEach(function (item) {
 							if (item.command && item.command !== commandName) {
 								otherButtons.push(item.command);
+								if (statelessButtonsList.includes(item.command)) {
+									statelessButtons.push(item);
+								}
 							} else if (!item.command && typeof item.setState !== "undefined") {
 								combos.push(item);
 							}
@@ -201,6 +220,14 @@ CKEDITOR.plugins.add('taofurigana', {
 					if (deleteRubyIfNoRt(range.startContainer, false, selection)) {
 						command.setState(CKEDITOR.TRISTATE_DISABLED);
 						setButtonsState(CKEDITOR.TRISTATE_OFF);
+					} else if (!isInRtFugirana(range.startContainer)) {
+						command.setState(CKEDITOR.TRISTATE_ON);
+						setTimeout(function () {
+							setButtonsState(CKEDITOR.TRISTATE_DISABLED);
+							statelessButtons.forEach(function (button) {
+								button.setState(CKEDITOR.TRISTATE_OFF);
+							});
+						}, 150);
 					} else {
 						command.setState(CKEDITOR.TRISTATE_ON);
 						setTimeout(function () {


### PR DESCRIPTION
## What is the purpose of this pull request?
https://oat-sa.atlassian.net/browse/AUT-4506

added whitelist for state less buttons for ruby tag text content

![chrome_gecEh4Zk8P](https://github.com/user-attachments/assets/f6223ae2-63d2-4573-939c-9252868d3780)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined ruby (furigana) toolbar behavior so buttons reliably reflect availability when creating, editing, or selecting readings; some buttons are now temporarily disabled or turned off to prevent accidental actions.

* **Chores**
  * Build/release tooling updated with a new release suffix and an adjusted Java invocation; unminified build handling improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->