### PR TITLE
fix: taofurigana cursor placement without nbsp placeholders (INF-466)

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -215,6 +215,53 @@ CKEDITOR.plugins.add('taofurigana', {
 			}
 		}
 
+		/**
+		 * Remove zero-width placeholders from rt and unwrap empty ruby nodes.
+		 * @param {CkEditor} editor - ckEditor instance
+		 * @param {Boolean} useSnapshots - Wrap ruby unwrapping with snapshot lock.
+		 * @returns {boolean}
+		 */
+		function cleanupRubyElements(editor, useSnapshots) {
+			var rubyElements = editor.document.find('ruby');
+			var modified = false;
+
+			for (var i = 0; i < rubyElements.count(); i++) {
+				var ruby = rubyElements.getItem(i);
+				var rtElement = ruby.find('rt');
+
+				if (rtElement.$.length) {
+					var rtDom = rtElement.getItem(0).$;
+					var originalInnerHTML = rtDom.innerHTML;
+					rtDom.innerHTML = rtDom.innerHTML.replace(/\u200B/g, '');
+					if (originalInnerHTML !== rtDom.innerHTML) {
+						modified = true;
+					}
+				}
+
+				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
+					var rbElement = ruby.find('rb');
+					if (rbElement.$.length) {
+						if (useSnapshots) {
+							editor.fire('saveSnapshot');
+							editor.fire('lockSnapshot');
+						}
+
+						try {
+							var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
+							rbHtml.replace(ruby);
+							modified = true;
+						} finally {
+							if (useSnapshots) {
+								editor.fire('unlockSnapshot');
+							}
+						}
+					}
+				}
+			}
+
+			return modified;
+		}
+
 		// Create the command that can be used to apply the style.
 		editor.addCommand(commandName, {
 			exec: function (editor) {
@@ -304,38 +351,11 @@ CKEDITOR.plugins.add('taofurigana', {
 				refreshCommandState(editor);
 			});
 		});
+		editor.on('beforeGetData', function() {
+			cleanupRubyElements(editor, false);
+		});
 		editor.on('blur', function() {
-			// Get all ruby elements in the editor
-			var rubyElements = editor.document.find('ruby');
-			var modified = false;
-
-			for (var i = 0; i < rubyElements.count(); i++) {
-				var ruby = rubyElements.getItem(i);
-				var rtElement = ruby.find('rt');
-
-				if (rtElement.$.length) {
-					var rtDom = rtElement.getItem(0).$;
-					var originalInnerHTML = rtDom.innerHTML;
-					rtDom.innerHTML = rtDom.innerHTML.replace(/\u200B/g, '');
-					if (originalInnerHTML !== rtDom.innerHTML) {
-						modified = true;
-					}
-				}
-
-				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
-					var rbElement = ruby.find('rb');
-					if (rbElement.$.length) {
-						editor.fire('saveSnapshot');
-						editor.fire('lockSnapshot');
-
-						var rbHtml = new CKEDITOR.dom.element.createFromHtml(rbElement.$[0].innerHTML);
-						rbHtml.replace(ruby);
-
-						editor.fire('unlockSnapshot');
-						modified = true;
-					}
-				}
-			}
+			var modified = cleanupRubyElements(editor, true);
 			//update editor textarea
 			if (modified) {
 				//

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -265,14 +265,12 @@ CKEDITOR.plugins.add('taofurigana', {
 					rbElement = new CKEDITOR.dom.element('rb', editor.document);
 					rbElement.append(getSelectionContent(selection));
 					rtElement = new CKEDITOR.dom.element('rt', editor.document);
-					rtElement.appendHtml('&nbsp;');
 					rubyElement.append(rbElement);
 					rubyElement.append(rtElement);
 
 					// create a temporary element for binding the cursor
 					var anchor = new CKEDITOR.dom.element('span', editor.document);
 					rtElement.append(anchor);
-					rtElement.appendHtml('&nbsp;');
 
 					editor.insertElement(rubyElement);
 					// add a zero-width space for the better navigation in Chrome (version >= 128) to the next sibling

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -315,7 +315,11 @@ CKEDITOR.plugins.add('taofurigana', {
 
 				if (rtElement.$.length) {
 					var rtDom = rtElement.getItem(0).$;
+					var originalInnerHTML = rtDom.innerHTML;
 					rtDom.innerHTML = rtDom.innerHTML.replace(/\u200B/g, '');
+					if (originalInnerHTML !== rtDom.innerHTML) {
+						modified = true;
+					}
 				}
 
 				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -268,9 +268,9 @@ CKEDITOR.plugins.add('taofurigana', {
 					rubyElement.append(rbElement);
 					rubyElement.append(rtElement);
 
-					// create a temporary element for binding the cursor
-					var anchor = new CKEDITOR.dom.element('span', editor.document);
-					rtElement.append(anchor);
+					// create a temporary text node for cursor placement without spaces
+					var rtPlaceholder = new CKEDITOR.dom.text('\u200b', editor.document);
+					rtElement.append(rtPlaceholder);
 
 					editor.insertElement(rubyElement);
 					// add a zero-width space for the better navigation in Chrome (version >= 128) to the next sibling
@@ -280,17 +280,15 @@ CKEDITOR.plugins.add('taofurigana', {
 						zeroWidthSpace.insertAfter(rubyElement);
 					}
 
-					// move cursor inside the anchor
+					// move cursor inside rt placeholder text node
 					range = new CKEDITOR.dom.range(editor.document);
-					range.setStart(anchor, 0);
+					range.setStart(rtPlaceholder, 1);
 					range.collapse(true);
 					editor.getSelection().removeAllRanges();
 					editor.getSelection().selectRanges([range]);
 					refreshCommandState(editor);
 
 					editor.fire('unlockSnapshot');
-					// remove anchor
-					anchor.remove();
 				}
 			}
 		});
@@ -314,6 +312,11 @@ CKEDITOR.plugins.add('taofurigana', {
 			for (var i = 0; i < rubyElements.count(); i++) {
 				var ruby = rubyElements.getItem(i);
 				var rtElement = ruby.find('rt');
+
+				if (rtElement.$.length) {
+					var rtDom = rtElement.getItem(0).$;
+					rtDom.innerHTML = rtDom.innerHTML.replace(/\u200B/g, '');
+				}
 
 				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
 					var rbElement = ruby.find('rb');


### PR DESCRIPTION
## Summary
- fix `taofurigana` insertion to avoid `&nbsp;` placeholders in new `rt`
- keep cursor jump working by setting selection inside a temporary zero-width text node
- clean temporary zero-width placeholder on blur

## Why
- removing placeholder spaces fixes unwanted boundary spaces in ruby annotations
- previous variant broke cursor focus; this patch restores expected UX

## Related
- INF-466

https://github.com/user-attachments/assets/2680776a-bfa1-419f-a6e5-b8ee7667bcc7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ruby (furigana) now uses an invisible placeholder for entry, eliminating visible artifacts.
  * More reliable caret placement when adding ruby so the cursor appears predictably.
  * Centralized cleanup of ruby placeholders runs both when retrieving document data and on blur, preventing stray characters and removing empty ruby elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->