### PR TITLE
Fix/inf 465/ruby disabled on mouseup

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -301,9 +301,9 @@ CKEDITOR.plugins.add('taofurigana', {
 			var command = editor.getCommand(commandName);
 			command.setState(CKEDITOR.TRISTATE_DISABLED);
 
-			editable.attachListener(editable, 'mouseup', function () {
-				refreshCommandState(editor);
-			});
+			editable.attachListener(CKEDITOR.document, 'mouseup', function () {
+                refreshCommandState(editor);
+            });
 			editable.attachListener(editable, 'keyup', function () {
 				refreshCommandState(editor);
 			});


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-465


<img width="381" height="241" alt="Screenshot_1" src="https://github.com/user-attachments/assets/cdb3e994-b0ca-4702-b122-eea93d10ba42" />

.
Authoring, A-block editing, "Ruby" button in the CkEditor toolbar.
1. Start selecting text with mouse --> mouseup _outside_ the A-block borders  --> button does not become active --> bug, fixed here
2. Start selecting text with mouse --> mouseup _inside_ the A-block borders  --> button becomes active --> good

See video in the ticket description.

### Related PRs:
- https://github.com/oat-sa/ckeditor-dev/pull/64
- https://github.com/oat-sa/tao-core-shared-libs-fe/pull/68
- https://github.com/oat-sa/tao-core/pull/4422


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved furigana button state refresh by adjusting how mouse interactions are detected, making the button more responsive and reliable during text editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->