### PR TITLE
fix: prevent furigana caret jump and strip zwsp on export

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -341,6 +341,9 @@ CKEDITOR.plugins.add('taofurigana', {
 					rtElement.append(rtPlaceholder);
 
 					editor.insertElement(rubyElement);
+					// add a zero-width helper after ruby for Chrome caret/navigation behavior
+					var zeroWidthSpace = new CKEDITOR.dom.text('\u200b', editor.document);
+					zeroWidthSpace.insertAfter(rubyElement);
 
 					// move cursor inside rt placeholder text node
 					range = new CKEDITOR.dom.range(editor.document);

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -4,7 +4,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		'use strict';
 
 		var commandName = 'rubyFurigana';
-		var zeroWidthCharsRegex = /[\u200B\u200C\u200D\uFEFF]/g;
+		var placeholderCharRegex = /\u200B/g;
 		var containsTag;
 		var otherButtons = [];
 		var combos = [];
@@ -232,7 +232,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 				if (rtElement.$.length) {
 					var rtNode = rtElement.getItem(0);
-					var rtText = rtNode.getText().replace(zeroWidthCharsRegex, '');
+					var rtText = rtNode.getText().replace(placeholderCharRegex, '');
 					if (rtText.trim() !== '') {
 						continue;
 					}
@@ -381,7 +381,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		});
 		editor.on('getData', function(event) {
 			if (event.data && typeof event.data.dataValue === 'string') {
-				event.data.dataValue = event.data.dataValue.replace(zeroWidthCharsRegex, '');
+				event.data.dataValue = event.data.dataValue.replace(placeholderCharRegex, '');
 			}
 		});
 		editor.ui.addButton('TaoFurigana', {

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -4,6 +4,7 @@ CKEDITOR.plugins.add('taofurigana', {
 		'use strict';
 
 		var commandName = 'rubyFurigana';
+		var zeroWidthCharsRegex = /[\u200B\u200C\u200D\uFEFF]/g;
 		var containsTag;
 		var otherButtons = [];
 		var combos = [];
@@ -229,7 +230,13 @@ CKEDITOR.plugins.add('taofurigana', {
 				var ruby = rubyElements.getItem(i);
 				var rtElement = ruby.find('rt');
 
-				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
+				if (rtElement.$.length) {
+					var rtNode = rtElement.getItem(0);
+					var rtText = rtNode.getText().replace(zeroWidthCharsRegex, '');
+					if (rtText.trim() !== '') {
+						continue;
+					}
+
 					var rbElement = ruby.find('rb');
 					if (rbElement.$.length) {
 						if (useSnapshots) {
@@ -336,9 +343,20 @@ CKEDITOR.plugins.add('taofurigana', {
 				refreshCommandState(editor);
 			});
 		});
+		editor.on('beforeGetData', function() {
+			cleanupRubyElements(editor, false);
+		});
+		editor.on('blur', function() {
+			var modified = cleanupRubyElements(editor, true);
+			if (modified) {
+				editor.updateElement();
+				editor.fire('change');
+				refreshCommandState(editor);
+			}
+		});
 		editor.on('getData', function(event) {
 			if (event.data && typeof event.data.dataValue === 'string') {
-				event.data.dataValue = event.data.dataValue.replace(/\u200B/g, '');
+				event.data.dataValue = event.data.dataValue.replace(zeroWidthCharsRegex, '');
 			}
 		});
 		editor.ui.addButton('TaoFurigana', {

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -229,15 +229,6 @@ CKEDITOR.plugins.add('taofurigana', {
 				var ruby = rubyElements.getItem(i);
 				var rtElement = ruby.find('rt');
 
-				if (rtElement.$.length) {
-					var rtDom = rtElement.getItem(0).$;
-					var originalInnerHTML = rtDom.innerHTML;
-					rtDom.innerHTML = rtDom.innerHTML.replace(/\u200B/g, '');
-					if (originalInnerHTML !== rtDom.innerHTML) {
-						modified = true;
-					}
-				}
-
 				if (rtElement.$.length && rtElement.$[0].innerText.trim() === '') {
 					var rbElement = ruby.find('rb');
 					if (rbElement.$.length) {
@@ -320,12 +311,6 @@ CKEDITOR.plugins.add('taofurigana', {
 					rtElement.append(rtPlaceholder);
 
 					editor.insertElement(rubyElement);
-					// add a zero-width space for the better navigation in Chrome (version >= 128) to the next sibling
-					var nextSibling = rubyElement.getNext();
-					if (!nextSibling || (nextSibling.type === CKEDITOR.NODE_TEXT && nextSibling.getText().trim() === '')) {
-						var zeroWidthSpace = new CKEDITOR.dom.text('\u200b', editor.document);
-						zeroWidthSpace.insertAfter(rubyElement);
-					}
 
 					// move cursor inside rt placeholder text node
 					range = new CKEDITOR.dom.range(editor.document);
@@ -351,19 +336,9 @@ CKEDITOR.plugins.add('taofurigana', {
 				refreshCommandState(editor);
 			});
 		});
-		editor.on('beforeGetData', function() {
-			cleanupRubyElements(editor, false);
-		});
-		editor.on('blur', function() {
-			var modified = cleanupRubyElements(editor, true);
-			//update editor textarea
-			if (modified) {
-				//
-				editor.updateElement();
-
-				editor.fire('change');
-
-				refreshCommandState(editor);
+		editor.on('getData', function(event) {
+			if (event.data && typeof event.data.dataValue === 'string') {
+				event.data.dataValue = event.data.dataValue.replace(/\u200B/g, '');
 			}
 		});
 		editor.ui.addButton('TaoFurigana', {

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -260,6 +260,29 @@ CKEDITOR.plugins.add('taofurigana', {
 			return modified;
 		}
 
+		/**
+		 * Cleanup empty ruby nodes when current selection is outside ruby.
+		 * @param {CkEditor} editor - ckEditor instance
+		 */
+		function cleanupIfSelectionOutsideRuby(editor) {
+			var selection = editor.getSelection();
+			if (!selection || !selection.getRanges || !selection.getRanges().length) {
+				return;
+			}
+
+			var range = selection.getRanges()[0];
+			var startInRuby = range.startContainer && isInFugirana(range.startContainer);
+			var endInRuby = range.endContainer && isInFugirana(range.endContainer);
+
+			if (!startInRuby && !endInRuby) {
+				var modified = cleanupRubyElements(editor, true);
+				if (modified) {
+					editor.updateElement();
+					editor.fire('change');
+				}
+			}
+		}
+
 		// Create the command that can be used to apply the style.
 		editor.addCommand(commandName, {
 			exec: function (editor) {
@@ -337,9 +360,11 @@ CKEDITOR.plugins.add('taofurigana', {
 			command.setState(CKEDITOR.TRISTATE_DISABLED);
 
 			editable.attachListener(editable, 'mouseup', function () {
+				cleanupIfSelectionOutsideRuby(editor);
 				refreshCommandState(editor);
 			});
 			editable.attachListener(editable, 'keyup', function () {
+				cleanupIfSelectionOutsideRuby(editor);
 				refreshCommandState(editor);
 			});
 		});


### PR DESCRIPTION
This pull request simplifies and improves the handling of zero-width spaces (`\u200B`) in the `taofurigana` CKEditor plugin, particularly in how they are managed during editing and data retrieval. The changes remove unnecessary insertion and cleanup of zero-width spaces, and instead ensure that any lingering zero-width spaces are stripped out when retrieving the editor's data.

**Zero-width space handling improvements:**

* Removed the logic that inserted a zero-width space after a `ruby` element for Chrome navigation, simplifying the insertion process.
* Removed the cleanup of zero-width spaces from the `cleanupRubyElements` function, and instead now strip all zero-width spaces from the editor data during the `getData` event. [[1]](diffhunk://#diff-f7a65004efe50c21e6044eb1b12926897bba5af6d134ee6545e728046f359f28L232-L240) [[2]](diffhunk://#diff-f7a65004efe50c21e6044eb1b12926897bba5af6d134ee6545e728046f359f28L354-R341)

**Event handling refactor:**

* Replaced the `beforeGetData` and `blur` event handlers (which previously called `cleanupRubyElements`) with a single `getData` event handler that removes zero-width spaces directly from the data being retrieved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ruby/annotation elements no longer leave stray invisible placeholder characters after editing or export.
  * Ruby elements are automatically cleaned/unwrapped when the selection moves outside them, preventing orphaned markup.

* **Refactor**
  * Data retrieval now strips hidden placeholder characters for cleaner copy/export.
  * Editor now always inserts a thin spacer after creating a ruby and has a tightened blur behavior that only triggers updates when cleanup made changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->