### PR TITLE
[INF-399] Fix: fix error when ruby spotted outside ckeditor

### DIFF
--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -672,7 +672,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				return;
 			}
 
-			var rubyList = editor.document.find('ruby');
+			var rubyList = editor.element.find('ruby');
 			if (!rubyList.count()) {
 				return;
 			}


### PR DESCRIPTION
## What is the purpose of this pull request?
https://oat-sa.atlassian.net/browse/INF-399
Issue related https://oat-sa.atlassian.net/browse/INF-401 feature, when some ruby tag is presented outside ckeditor, script if failing.

Bug fix:

<img width="1840" height="972" alt="image" src="https://github.com/user-attachments/assets/c39971e2-c802-44ce-b20b-6fb33db1ccae" />

With fix:

<img width="1840" height="972" alt="image" src="https://github.com/user-attachments/assets/cde1fb8f-9a50-4724-a12e-27c25deb2362" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ruby element anchor preservation in the taofurigana plugin to ensure proper handling and maintenance of text structure formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/ckeditor-dev/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->