### PR TITLE
fix: orphan ZWS after linebreak deletes whole line on Backspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ The built versions checksums aren't identical because the source code contains t
 - To use the uncompiled version of CK for development purposes, please use `--unminified` flag: `./build.sh --unminified `
 - For furigana/ruby work, open [`samples/taofurigana.html`](samples/taofurigana.html) in a browser (dev loader — no build). Edit `plugins/taofurigana/plugin.js` and refresh.
 - To test inside qtiCreator: build then sync (do **not** symlink the unbuilt tree — the web server cannot serve paths outside the docroot, and TAO needs the built `ckeditor.js` where `taofurigana` is compiled in):
-  1. `cd dev/builder && ./build.sh --unminified`
-  2. `./scripts/link-to-tao.sh sync`
-  3. Hard-refresh backoffice; `./scripts/link-to-tao.sh restore` when done.
+  1. Set `CKEDITOR_DEV` and `TAO_CORE_VIEWS` (export them, or edit the PATH CONFIG block in `scripts/link-to-tao.sh`)
+  2. `cd dev/builder && ./build.sh --unminified`
+  3. `./scripts/link-to-tao.sh sync`
+  4. Hard-refresh backoffice; `./scripts/link-to-tao.sh restore` when done.
 
 #### TAO Skin
 - If you need to modify TAO skin, you'll find the SASS source files in [`@oat-sa/tao-core-ui-fe`](https://github.com/oat-sa/tao-core-ui-fe/tree/master/scss/ckeditor/skins/tao/scss). They are not in this repo.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The built versions checksums aren't identical because the source code contains t
 
 #### CK Playground
 - To use the uncompiled version of CK for development purposes, please use `--unminified` flag: `./build.sh --unminified `
+- For furigana/ruby work, open [`samples/taofurigana.html`](samples/taofurigana.html) in a browser (dev loader — no build). Edit `plugins/taofurigana/plugin.js` and refresh.
+- To test inside qtiCreator: build then sync (do **not** symlink the unbuilt tree — the web server cannot serve paths outside the docroot, and TAO needs the built `ckeditor.js` where `taofurigana` is compiled in):
+  1. `cd dev/builder && ./build.sh --unminified`
+  2. `./scripts/link-to-tao.sh sync`
+  3. Hard-refresh backoffice; `./scripts/link-to-tao.sh restore` when done.
 
 #### TAO Skin
 - If you need to modify TAO skin, you'll find the SASS source files in [`@oat-sa/tao-core-ui-fe`](https://github.com/oat-sa/tao-core-ui-fe/tree/master/scss/ckeditor/skins/tao/scss). They are not in this repo.

--- a/plugins/taofurigana/lang/en.js
+++ b/plugins/taofurigana/lang/en.js
@@ -1,4 +1,4 @@
-CKEDITOR.plugins.setLang( 'rubyFurigana', 'en', {
+CKEDITOR.plugins.setLang( 'taofurigana', 'en', {
 	button: 'Insert Furigana (Ruby)',
 	title: 'Insert Furigana (Ruby)'
 } );

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -19,6 +19,9 @@ CKEDITOR.plugins.add('taofurigana', {
 		var keyCodeDelete = 46;
 		var keyCodeBackspace = 8;
 		var keyCodeLeftArrow = 37;
+		var refreshCommandStateTimer = null;
+		var disableToolbarButtonsTimer = null;
+		var lastFuriganaCommandState = null;
 
 		/**
 		 * @param {CKEDITOR.dom.selection} selection
@@ -311,6 +314,122 @@ CKEDITOR.plugins.add('taofurigana', {
 		}
 
 		/**
+		 * Place caret at the end of rt (before the trailing ZWS anchor) so Backspace
+		 * deletes furigana from the end of the reading.
+		 * @param {CKEDITOR.dom.element} rtElement
+		 */
+		function placeCaretAtRtEnd(rtElement) {
+			var anchors = ensureRtAnchors(rtElement);
+			var selection = editor.getSelection();
+			var range = new CKEDITOR.dom.range(editor.document);
+
+			range.setStartBefore(anchors.endAnchor);
+			range.collapse(true);
+			selection.selectRanges([range]);
+		}
+
+		/**
+		 * Keep hasRuby in sync so keydown/selection listeners stop after the last ruby is gone.
+		 * Leaving it stuck true makes every Backspace run orphan-ZWS walks and feels laggy.
+		 */
+		function refreshHasRubyFlag() {
+			var root = editor.editable() || editor.document;
+			hasRuby = !!(root && root.find('ruby').count());
+		}
+
+		/**
+		 * @param {CKEDITOR.dom.node} startNode
+		 */
+		function ensurePlaceholderForRt(startNode) {
+			if (!startNode || !startNode.getAscendant) {
+				return;
+			}
+
+			var rtElement = startNode.getAscendant('rt', true);
+
+			// Do not re-seed ZWS into an empty rt — that causes Backspace to thrash
+			// textLen 0↔1 forever (see INF-530 probe). New rubies get anchors at create time.
+			if (rtElement && !isEffectivelyEmpty(rtElement)) {
+				ensureRtAnchors(rtElement);
+			}
+		}
+
+		/**
+		 * Replace ruby with plain base text and put caret at the end of that text
+		 * so further Backspace deletes the base word normally.
+		 * @param {CKEDITOR.dom.element} rubyElement
+		 * @param {CKEDITOR.dom.selection} [selection]
+		 * @returns {CKEDITOR.dom.text|null}
+		 */
+		function unwrapRubyToBaseText(rubyElement, selection) {
+			if (!rubyElement) {
+				return null;
+			}
+
+			var rbElements = rubyElement.find('rb');
+			var rbElement = rbElements.count() ? rbElements.getItem(0) : null;
+			var baseText = rbElement ? rbElement.getText().replace(zeroWidthSpaceRegex, '') : '';
+			var replacement = new CKEDITOR.dom.text(baseText, editor.document);
+
+			replacement.replace(rubyElement);
+			cleanupZwsAnchor(replacement.getNext());
+			cleanupOrphanedZwsAfter(replacement);
+			refreshHasRubyFlag();
+
+			if (selection) {
+				var range = new CKEDITOR.dom.range(editor.document);
+				range.setStart(replacement, replacement.getText().length);
+				range.collapse(true);
+				selection.selectRanges([range]);
+			}
+
+			return replacement;
+		}
+
+		/**
+		 * When rt has no visible furigana left, Backspace/Delete should unwrap ruby
+		 * instead of deleting ZWS anchors that ensureRtAnchors immediately re-inserts.
+		 * @param {CKEDITOR.dom.selection} selection
+		 * @param {Number} keyCode
+		 * @returns {Boolean}
+		 */
+		function guardEmptyRtUnwrap(selection, keyCode) {
+			if (
+				(keyCode !== keyCodeBackspace && keyCode !== keyCodeDelete) ||
+				!selection ||
+				!selection.isCollapsed()
+			) {
+				return false;
+			}
+
+			var range = selection.getRanges()[0];
+			if (!range || !range.startContainer || !range.startContainer.getAscendant) {
+				return false;
+			}
+
+			var rtElement = range.startContainer.getAscendant('rt', true);
+			if (!rtElement || !isEffectivelyEmpty(rtElement)) {
+				return false;
+			}
+
+			var rubyElement = rtElement.getAscendant('ruby', true);
+			if (!rubyElement) {
+				return false;
+			}
+
+			editor.fire('saveSnapshot');
+			editor.fire('lockSnapshot');
+			try {
+				unwrapRubyToBaseText(rubyElement, selection);
+				editor.fire('change');
+			} finally {
+				editor.fire('unlockSnapshot');
+			}
+
+			return true;
+		}
+
+		/**
 		 * Delete first visible rt character when caret is before it.
 		 * @param {CKEDITOR.dom.selection} selection
 		 * @param {Number} keyCode
@@ -336,6 +455,10 @@ CKEDITOR.plugins.add('taofurigana', {
 				return false;
 			}
 
+			if (isEffectivelyEmpty(rtElement)) {
+				return guardEmptyRtUnwrap(selection, keyCode);
+			}
+
 			ensureRtAnchors(rtElement);
 			var firstVisiblePosition = getFirstVisibleCharPosition(rtElement);
 
@@ -349,36 +472,20 @@ CKEDITOR.plugins.add('taofurigana', {
 				var text = firstVisiblePosition.node.getText();
 				firstVisiblePosition.node.$.nodeValue =
 					text.slice(0, firstVisiblePosition.offset) + text.slice(firstVisiblePosition.offset + 1);
-				ensureRtAnchors(rtElement);
-				placeCaretAtRtStart(rtElement);
+
+				if (isEffectivelyEmpty(rtElement)) {
+					var rubyElement = rtElement.getAscendant('ruby', true);
+					unwrapRubyToBaseText(rubyElement, selection);
+				} else {
+					ensureRtAnchors(rtElement);
+					placeCaretAtRtStart(rtElement);
+				}
 			} finally {
 				editor.fire('unlockSnapshot');
 			}
 
 			return true;
 		}
-
-		/**
-		 * @param {CKEDITOR.dom.node} startNode
-		 */
-		function ensurePlaceholderForRt(startNode) {
-			if (!startNode || !startNode.getAscendant) {
-				return;
-			}
-
-			var rtElement = startNode.getAscendant('rt', true);
-
-			if (rtElement) {
-				ensureRtAnchors(rtElement);
-			}
-		}
-
-		/**
-		 * Keep collapsed caret inside ruby top text to prevent input leaking to rb.
-		 * @param {CKEDITOR.dom.selection} selection
-		 * @param {CKEDITOR.dom.node} [targetNode]
-		 * @returns {Boolean}
-		 */
 		function normalizeCaretIntoRt(selection, targetNode) {
 			if (isNormalizingSelection || !selection || !selection.isCollapsed()) {
 				return false;
@@ -394,13 +501,22 @@ CKEDITOR.plugins.add('taofurigana', {
 				return false;
 			}
 
+			// Base text (bottom): leave caret alone so Backspace/Delete stay responsive.
+			if (startContainer.getAscendant('rb', true)) {
+				return false;
+			}
+
 			var currentRtElement = startContainer.getAscendant('rt', true);
 			if (currentRtElement) {
+				if (isEffectivelyEmpty(currentRtElement)) {
+					return false;
+				}
 				var isAtRtStart = range.startOffset === 0;
-				ensureRtAnchors(currentRtElement);
+				// Only repair anchors when caret is on the leading edge; skip DOM work mid-rt.
 				if (!isAtRtStart) {
 					return false;
 				}
+				ensureRtAnchors(currentRtElement);
 			}
 
 			var rubyElement = targetNode && targetNode.getAscendant ? targetNode.getAscendant('ruby', true) : null;
@@ -464,10 +580,167 @@ CKEDITOR.plugins.add('taofurigana', {
 		}
 
 		/**
+		 * Next DOM node after `node`, crossing empty parents up to the editable
+		 * so orphans separated by a line break / new block can be found.
+		 * @param {CKEDITOR.dom.node} node
+		 * @returns {CKEDITOR.dom.node|null}
+		 */
+		function getNextNodeCrossingBoundaries(node) {
+			if (!node) {
+				return null;
+			}
+
+			var next = node.getNext();
+			if (next) {
+				return next;
+			}
+
+			var parent = node.getParent();
+			var editable = editor.editable();
+			while (parent && editable && !parent.equals(editable)) {
+				next = parent.getNext();
+				if (next) {
+					return next;
+				}
+				parent = parent.getParent();
+			}
+
+			return null;
+		}
+
+		/**
+		 * True when node is a trailing-ruby ZWS that is no longer immediately after a ruby
+		 * (e.g. Enter moved it onto the next line before ruby was removed).
+		 * @param {CKEDITOR.dom.node} node
+		 * @returns {Boolean}
+		 */
+		function isOrphanZwsAnchor(node) {
+			return isZwsAnchorAfterRuby(node) && !isRubyNode(node.getPrevious());
+		}
+
+		/**
+		 * Remove orphaned ZWS anchors that may sit after `fromNode`, including across
+		 * `<br>` and the next block (ENTER_P / ENTER_BR line breaks).
+		 * @param {CKEDITOR.dom.node} fromNode
+		 * @returns {Boolean} true if an orphan ZWS was removed
+		 */
+		function cleanupOrphanedZwsAfter(fromNode) {
+			if (!fromNode) {
+				return false;
+			}
+
+			var node = getNextNodeCrossingBoundaries(fromNode);
+			var guard = 0;
+
+			while (node && guard < 50) {
+				guard++;
+
+				if (isOrphanZwsAnchor(node)) {
+					cleanupZwsAnchor(node);
+					return true;
+				}
+
+				if (isEmptyTextNode(node)) {
+					node = getNextNodeCrossingBoundaries(node);
+					continue;
+				}
+
+				if (node.type === CKEDITOR.NODE_ELEMENT) {
+					var name = node.getName && node.getName();
+					if (name === 'br') {
+						node = getNextNodeCrossingBoundaries(node);
+						continue;
+					}
+
+					var first = node.getFirst && node.getFirst();
+					if (first) {
+						if (isOrphanZwsAnchor(first)) {
+							cleanupZwsAnchor(first);
+							return true;
+						}
+						// Dive into the next block / wrapper to find a leading orphan ZWS.
+						node = first;
+						continue;
+					}
+
+					node = getNextNodeCrossingBoundaries(node);
+					continue;
+				}
+
+				// Visible content — stop searching.
+				break;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Chrome can delete a whole line when Backspace hits an orphan ZWS left after
+		 * ruby removal across a line break. Strip that ZWS before native delete runs.
+		 * @param {CKEDITOR.dom.selection} selection
+		 * @param {Number} keyCode
+		 * @returns {Boolean}
+		 */
+		function guardOrphanZwsBackspace(selection, keyCode) {
+			if (keyCode !== keyCodeBackspace || !selection || !selection.isCollapsed()) {
+				return false;
+			}
+
+			var range = selection.getRanges()[0];
+			if (!range || !range.startContainer) {
+				return false;
+			}
+
+			var startContainer = range.startContainer;
+			var startOffset = range.startOffset;
+			var cleaned = false;
+
+			editor.fire('lockSnapshot');
+			try {
+				if (
+					startContainer.type === CKEDITOR.NODE_TEXT &&
+					isOrphanZwsAnchor(startContainer) &&
+					startOffset <= 1
+				) {
+					cleanupZwsAnchor(startContainer);
+					cleaned = true;
+				} else if (startContainer.type === CKEDITOR.NODE_ELEMENT && startOffset === 0) {
+					var child = startContainer.getChild(startOffset);
+					if (isOrphanZwsAnchor(child)) {
+						cleanupZwsAnchor(child);
+						cleaned = true;
+					}
+				}
+
+				// Only search across the boundary when the next node looks like an orphan ZWS,
+				// so normal Backspace at end-of-word is not delayed after ruby was removed.
+				if (!cleaned) {
+					var atEndOfText =
+						startContainer.type === CKEDITOR.NODE_TEXT &&
+						startOffset >= startContainer.getText().length;
+					var atEndOfBlock = range.checkEndOfBlock && range.checkEndOfBlock();
+
+					if (atEndOfText || atEndOfBlock) {
+						var next = getNextNodeCrossingBoundaries(startContainer);
+						var nextFirst = next && next.type === CKEDITOR.NODE_ELEMENT && next.getFirst ? next.getFirst() : null;
+						if (isOrphanZwsAnchor(next) || isOrphanZwsAnchor(nextFirst)) {
+							cleaned = cleanupOrphanedZwsAfter(startContainer);
+						}
+					}
+				}
+			} finally {
+				editor.fire('unlockSnapshot');
+			}
+
+			return cleaned;
+		}
+
+		/**
 		 * Chrome issue: if caret is after ruby, and:
 		 *  - you press 'Backspace' -> *all content* before caret position gets deleted, not only ruby.
 		 *  - you press 'LeftArrow' -> caret moves to the very beginning of the content.
-		 * So, need to override native behavior for these keys. For simplicity, just move caret inside rt.
+		 * So, need to override native behavior for these keys. Place caret at end of rt so
+		 * Backspace continues deleting the reading from the end (Mac Delete = Backspace).
 		 * @param {CKEDITOR.dom.selection} selection
 		 * @param {Number} keyCode
 		 * @returns {Boolean}
@@ -493,10 +766,23 @@ CKEDITOR.plugins.add('taofurigana', {
 					return false;
 				}
 
+				// Empty reading: unwrap to base text instead of entering a ZWS-only rt.
+				if (keyCode === keyCodeBackspace && isEffectivelyEmpty(rtElement)) {
+					editor.fire('saveSnapshot');
+					editor.fire('lockSnapshot');
+					try {
+						unwrapRubyToBaseText(rubyElement, selection);
+						editor.fire('change');
+					} finally {
+						editor.fire('unlockSnapshot');
+					}
+					return true;
+				}
+
 				editor.fire('lockSnapshot');
 				try {
 					ensureRtAnchors(rtElement);
-					placeCaretAtRtStart(rtElement);
+					placeCaretAtRtEnd(rtElement);
 				} finally {
 					editor.fire('unlockSnapshot');
 				}
@@ -541,9 +827,13 @@ CKEDITOR.plugins.add('taofurigana', {
 				editor.fire('saveSnapshot');
 				editor.fire('lockSnapshot');
 				try {
+					var previousNode = rubyElement.getPrevious();
+					var parentNode = rubyElement.getParent();
 					var elementAfterRuby = rubyElement.getNext();
 					rubyElement.remove();
 					cleanupZwsAnchor(elementAfterRuby);
+					cleanupOrphanedZwsAfter(previousNode || parentNode);
+					refreshHasRubyFlag();
 				} finally {
 					editor.fire('unlockSnapshot');
 				}
@@ -672,8 +962,10 @@ CKEDITOR.plugins.add('taofurigana', {
 				return;
 			}
 
-			var rubyList = editor.element.find('ruby');
-			if (!rubyList.count()) {
+			var root = editor.editable() || editor.document || editor.element;
+			var rubyList = root && root.find ? root.find('ruby') : null;
+			if (!rubyList || !rubyList.count()) {
+				hasRuby = false;
 				return;
 			}
 
@@ -692,7 +984,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					// zero-space will get inside the wrapper: '<ruby>...</ruby><em>\u200b</em>'
 					// remove orphan zero-space from there and readd it after the ruby.
 					// (NB! we can't reliably know if it's "our" zero-space or not, but let's assume it is...)
-					if (next.getFirst && isZwsAnchorAfterRuby(next.getFirst())) {
+					if (next && next.getFirst && isZwsAnchorAfterRuby(next.getFirst())) {
 						cleanupZwsAnchor(next.getFirst());
 					}
 					insertZwsAnchorAfterRuby(rubyElement);
@@ -741,7 +1033,6 @@ CKEDITOR.plugins.add('taofurigana', {
 			var rtElements = rubyElement.find('rt');
 			var rbElement = rbElements.count() ? rbElements.getItem(0) : null;
 			var rtElement = rtElements.count() ? rtElements.getItem(0) : null;
-			var range;
 			if ((rbElement && !rtElement) || (byClick && rbElement && rtElement && isEffectivelyEmpty(rtElement))) {
 				// if rt is deleted
 				// of if click on toolbar button check that it is empty
@@ -749,19 +1040,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				editor.fire('saveSnapshot');
 				editor.fire('lockSnapshot');
 				try {
-					var baseText = rbElement ? rbElement.getText() : '';
-					var replacement = new CKEDITOR.dom.text(baseText, editor.document);
-					replacement.replace(rubyElement);
-
-					var nextSibling = replacement.getNext();
-					cleanupZwsAnchor(nextSibling);
-
-					if (!byClick) {
-						// keep caret on the base text
-						range = new CKEDITOR.dom.range(editor.document);
-						range.selectNodeContents(replacement);
-						selection.selectRanges([range]);
-					}
+					unwrapRubyToBaseText(rubyElement, byClick ? null : selection);
 					editor.fire('change');
 				} finally {
 					editor.fire('unlockSnapshot');
@@ -771,14 +1050,39 @@ CKEDITOR.plugins.add('taofurigana', {
 		}
 
 		/**
-		 * Change command state according to the current selection content
+		 * Change command state according to the current selection content.
+		 * Debounced: uncanceled setTimeout(150) on every keyup was stacking and making
+		 * Backspace/Delete feel progressively slower until blur drained the queue.
+		 * @param {CkEditor} editor - ckEditor instance
+		 * @param {Boolean} [immediate]
+		 */
+		function refreshCommandState(editor, immediate) {
+			if (!immediate) {
+				if (refreshCommandStateTimer) {
+					clearTimeout(refreshCommandStateTimer);
+				}
+				refreshCommandStateTimer = setTimeout(function () {
+					refreshCommandStateTimer = null;
+					refreshCommandStateNow(editor);
+				}, 50);
+				return;
+			}
+
+			if (refreshCommandStateTimer) {
+				clearTimeout(refreshCommandStateTimer);
+				refreshCommandStateTimer = null;
+			}
+			refreshCommandStateNow(editor);
+		}
+
+		/**
 		 * @param {CkEditor} editor - ckEditor instance
 		 */
-		function refreshCommandState(editor) {
+		function refreshCommandStateNow(editor) {
 			var command = editor.getCommand(commandName);
 			var selection = editor.getSelection();
-			var range = selection.getRanges()[0];
-			if (!otherButtons.length) {
+			var range = selection && selection.getRanges()[0];
+			if (!otherButtons.length && editor.toolbar) {
 				editor.toolbar.forEach(function (element) {
 					if (element.items && element.items.length) {
 						element.items.forEach(function (item) {
@@ -797,40 +1101,71 @@ CKEDITOR.plugins.add('taofurigana', {
 
 			function setButtonsState(state) {
 				otherButtons.forEach(function (button) {
-					// Refresh not applied properly
-					editor.getCommand(button).setState(!state);
-					editor.getCommand(button).setState(state);
+					var cmd = editor.getCommand(button);
+					if (cmd && cmd.state !== state) {
+						cmd.setState(state);
+					}
 				});
 				combos.forEach(function (combo) {
-					combo.setState(state);
+					if (combo.getState && combo.getState() !== state) {
+						combo.setState(state);
+					} else if (!combo.getState) {
+						combo.setState(state);
+					}
 				});
 			}
 
-			if (command) {
-				if (furiganaCanBeCreated(editor)) {
+			function scheduleDisableToolbarButtons() {
+				if (disableToolbarButtonsTimer) {
+					clearTimeout(disableToolbarButtonsTimer);
+				}
+				disableToolbarButtonsTimer = setTimeout(function () {
+					disableToolbarButtonsTimer = null;
+					setButtonsState(CKEDITOR.TRISTATE_DISABLED);
+					statelessButtons.forEach(function (button) {
+						button.setState(CKEDITOR.TRISTATE_OFF);
+					});
+				}, 150);
+			}
+
+			if (!command) {
+				return;
+			}
+
+			if (furiganaCanBeCreated(editor)) {
+				if (lastFuriganaCommandState !== CKEDITOR.TRISTATE_OFF) {
 					command.setState(CKEDITOR.TRISTATE_OFF);
 					setButtonsState(CKEDITOR.TRISTATE_OFF);
-				} else if (selection.getRanges()[0] && isInFugirana(range.startContainer)) {
-					if (deleteRubyIfNoRt(range.startContainer, false, selection)) {
-						command.setState(CKEDITOR.TRISTATE_DISABLED);
-						setButtonsState(CKEDITOR.TRISTATE_OFF);
-					} else if (!isInRtFugirana(range.startContainer)) {
-						command.setState(CKEDITOR.TRISTATE_ON);
-						setTimeout(function () {
-							setButtonsState(CKEDITOR.TRISTATE_DISABLED);
-							statelessButtons.forEach(function (button) {
-								button.setState(CKEDITOR.TRISTATE_OFF);
-							});
-						}, 150);
-					} else {
-						command.setState(CKEDITOR.TRISTATE_ON);
-						setTimeout(function () {
-							setButtonsState(CKEDITOR.TRISTATE_DISABLED);
-						}, 150);
-					}
-				} else {
+					lastFuriganaCommandState = CKEDITOR.TRISTATE_OFF;
+				}
+				if (disableToolbarButtonsTimer) {
+					clearTimeout(disableToolbarButtonsTimer);
+					disableToolbarButtonsTimer = null;
+				}
+			} else if (range && range.startContainer && isInFugirana(range.startContainer)) {
+				// Only auto-unwrap empty rt when caret is in rt — not on every rb keystroke.
+				if (isInRtFugirana(range.startContainer) && deleteRubyIfNoRt(range.startContainer, false, selection)) {
 					command.setState(CKEDITOR.TRISTATE_DISABLED);
 					setButtonsState(CKEDITOR.TRISTATE_OFF);
+					lastFuriganaCommandState = CKEDITOR.TRISTATE_DISABLED;
+					if (disableToolbarButtonsTimer) {
+						clearTimeout(disableToolbarButtonsTimer);
+						disableToolbarButtonsTimer = null;
+					}
+				} else if (lastFuriganaCommandState !== CKEDITOR.TRISTATE_ON) {
+					command.setState(CKEDITOR.TRISTATE_ON);
+					lastFuriganaCommandState = CKEDITOR.TRISTATE_ON;
+					scheduleDisableToolbarButtons();
+				}
+			} else {
+				if (lastFuriganaCommandState !== CKEDITOR.TRISTATE_DISABLED) {
+					command.setState(CKEDITOR.TRISTATE_DISABLED);
+					setButtonsState(CKEDITOR.TRISTATE_OFF);
+					lastFuriganaCommandState = CKEDITOR.TRISTATE_DISABLED;
+				}
+				if (disableToolbarButtonsTimer) {
+					clearTimeout(disableToolbarButtonsTimer);
+					disableToolbarButtonsTimer = null;
 				}
 			}
 		}
@@ -863,7 +1198,10 @@ CKEDITOR.plugins.add('taofurigana', {
 
 						var rbItem = rbElements.count() ? rbElements.getItem(0) : null;
 						if (!rbItem) {
+							var previousNode = ruby.getPrevious();
+							var parentNode = ruby.getParent();
 							ruby.remove();
+							cleanupOrphanedZwsAfter(previousNode || parentNode);
 						} else {
 							var rbInnerHtml = rbItem.$.innerHTML;
 							var replacement;
@@ -876,8 +1214,10 @@ CKEDITOR.plugins.add('taofurigana', {
 								replacement = new CKEDITOR.dom.text(rbItem.getText(), editor.document);
 							}
 							replacement.replace(ruby);
+							cleanupOrphanedZwsAfter(replacement);
 						}
 
+						refreshHasRubyFlag();
 						modified = true;
 					} finally {
 						if (useSnapshots) {
@@ -920,24 +1260,7 @@ CKEDITOR.plugins.add('taofurigana', {
 						editor.fire('lockSnapshot');
 
 						try {
-							var baseTextContent = '';
-							var rbNode = rbElement.getItem(0);
-							if (rbNode) {
-								baseTextContent = rbNode.getText();
-							}
-
-							var textNode = new CKEDITOR.dom.text(baseTextContent, editor.document);
-
-							textNode.replace(rubyElement);
-
-							var nextSibling = textNode.getNext();
-							cleanupZwsAnchor(nextSibling);
-
-							range = new CKEDITOR.dom.range(editor.document);
-							range.setStartAfter(textNode);
-							range.collapse(true);
-							selection.selectRanges([range]);
-
+							unwrapRubyToBaseText(rubyElement, selection);
 							editor.fire('change');
 							refreshCommandState(editor);
 						} finally {
@@ -985,7 +1308,7 @@ CKEDITOR.plugins.add('taofurigana', {
 			editable.attachListener(CKEDITOR.document, 'mouseup', function () {
 				if (isLastMousedownInsideEditor) {
 					isLastMousedownInsideEditor = false;
-					refreshCommandState(editor);
+					refreshCommandState(editor, true);
 
 					if (hasRuby) {
 						var selection = editor.getSelection();
@@ -1008,57 +1331,86 @@ CKEDITOR.plugins.add('taofurigana', {
 				refreshCommandState(editor);
 			});
 			editable.attachListener(editable, 'keydown', function (evt) {
-				if (hasRuby) {
-					var domEvent = evt && evt.data && evt.data.$ ? evt.data.$ : null;
-					var keyCode = domEvent ? domEvent.keyCode : null;
-					var selection = editor.getSelection();
+				if (!hasRuby) {
+					return;
+				}
 
-					if (
-						guardRtLeadingDelete(selection, keyCode) ||
-						guardLeftArrowFromRtLeadingZws(selection, keyCode) ||
-						guardBackspaceOrLeftArrowAfterRuby(selection, keyCode) ||
-						guardLastDeleteInRuby(selection, keyCode)
-					) {
-						if (evt && evt.data && evt.data.preventDefault) {
-							evt.data.preventDefault();
-						}
-						editor.fire('change');
-						refreshCommandState(editor);
+				var domEvent = evt && evt.data && evt.data.$ ? evt.data.$ : null;
+				var keyCode = domEvent ? domEvent.keyCode : null;
+				var selection = editor.getSelection();
+				var contentChanged = false;
+				var caretOnly = false;
+
+				if (guardEmptyRtUnwrap(selection, keyCode) || guardOrphanZwsBackspace(selection, keyCode) || guardRtLeadingDelete(selection, keyCode) || guardLastDeleteInRuby(selection, keyCode)) {
+					contentChanged = true;
+				} else if (guardLeftArrowFromRtLeadingZws(selection, keyCode) || guardBackspaceOrLeftArrowAfterRuby(selection, keyCode)) {
+					caretOnly = true;
+				}
+
+				if (contentChanged || caretOnly) {
+					if (evt && evt.data && evt.data.preventDefault) {
+						evt.data.preventDefault();
 					}
+					if (contentChanged) {
+						editor.fire('change');
+					}
+					refreshCommandState(editor);
 				}
 			});
+			// Do not call ensureZwsAnchorsAfterRuby here — every caret move during delete
+			// would re-enter DOM work. ZWS restore runs on change/dataReady instead.
 			editor.on('selectionChange', function () {
-				if (hasRuby) {
-					ensureZwsAnchorsAfterRuby();
-					normalizeCaret();
+				if (!hasRuby) {
+					return;
 				}
+
+				var selection = editor.getSelection();
+				var range = selection && selection.getRanges()[0];
+				var start = range && range.startContainer;
+				// Editing the base (bottom) word: skip normalize entirely.
+				if (start && start.getAscendant && start.getAscendant('rb', true)) {
+					return;
+				}
+
+				normalizeCaret();
 			});
 		});
 		editor.on('dataReady', function () {
 			ensureZwsAnchorsAfterRuby();
+			refreshHasRubyFlag();
 		});
 		editor.on('change', function () {
 			if (hasRuby) {
-		   		ensureZwsAnchorsAfterRuby();
+				ensureZwsAnchorsAfterRuby();
+				refreshHasRubyFlag();
 			}
 		});
 		editor.on('getData', function (evt) {
 			evt.data.dataValue = sanitizeRubyData(evt.data.dataValue);
 		});
 		editor.on('blur', function () {
+			if (refreshCommandStateTimer) {
+				clearTimeout(refreshCommandStateTimer);
+				refreshCommandStateTimer = null;
+			}
+			if (disableToolbarButtonsTimer) {
+				clearTimeout(disableToolbarButtonsTimer);
+				disableToolbarButtonsTimer = null;
+			}
+
 			var modified = cleanupEmptyRubyElements(editor, true);
 			//update editor textarea
 			if (modified) {
-				//
 				editor.updateElement();
 
 				editor.fire('change');
 
-				refreshCommandState(editor);
+				refreshCommandState(editor, true);
 			}
+			refreshHasRubyFlag();
 		});
 		editor.ui.addButton('TaoFurigana', {
-			label: editor.lang[commandName].button,
+			label: (editor.lang.rubyFurigana || editor.lang.taofurigana).button,
 			command: commandName,
 			icon: this.path + 'images/taofurigana.png'
 		});

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -355,11 +355,11 @@ CKEDITOR.plugins.add('taofurigana', {
 		}
 
 		/**
-		 * Replace ruby with plain base text and put caret at the end of that text
-		 * so further Backspace deletes the base word normally.
+		 * Replace ruby with its rb contents (preserving inline markup) and put caret
+		 * after the last inserted node so further Backspace deletes the base word normally.
 		 * @param {CKEDITOR.dom.element} rubyElement
 		 * @param {CKEDITOR.dom.selection} [selection]
-		 * @returns {CKEDITOR.dom.text|null}
+		 * @returns {CKEDITOR.dom.node|null}
 		 */
 		function unwrapRubyToBaseText(rubyElement, selection) {
 			if (!rubyElement) {
@@ -368,45 +368,57 @@ CKEDITOR.plugins.add('taofurigana', {
 
 			var rbElements = rubyElement.find('rb');
 			var rbElement = rbElements.count() ? rbElements.getItem(0) : null;
-			var replacement;
+			var nodes = [];
+			var lastNode;
+			var i;
 
-			if (!rbElement) {
-				replacement = new CKEDITOR.dom.text('', editor.document);
-			} else {
-				// Preserve inline markup inside rb (same approach as cleanupEmptyRubyElements).
+			if (rbElement) {
+				// Parse full rb contents so mixed text + inline markup (e.g. 漢<em>字</em>)
+				// is preserved — createFromHtml only keeps the first root node.
 				var rbInnerHtml = rbElement.$.innerHTML.replace(zeroWidthSpaceRegex, '');
 				try {
-					replacement = rbInnerHtml
-						? CKEDITOR.dom.element.createFromHtml(rbInnerHtml, editor.document)
-						: null;
+					if (rbInnerHtml) {
+						var temp = new CKEDITOR.dom.element('div', editor.document);
+						temp.setHtml(rbInnerHtml);
+						var child;
+						while ((child = temp.getFirst())) {
+							nodes.push(child.remove());
+						}
+					}
 				} catch (err) {
-					replacement = null;
-				}
-				if (!replacement || replacement.type === CKEDITOR.NODE_TEXT) {
-					replacement = new CKEDITOR.dom.text(
-						rbElement.getText().replace(zeroWidthSpaceRegex, ''),
-						editor.document
-					);
+					nodes = [];
 				}
 			}
 
-			replacement.replace(rubyElement);
-			cleanupZwsAnchor(replacement.getNext());
-			cleanupOrphanedZwsAfter(replacement);
+			if (!nodes.length) {
+				lastNode = new CKEDITOR.dom.text(
+					rbElement ? rbElement.getText().replace(zeroWidthSpaceRegex, '') : '',
+					editor.document
+				);
+				lastNode.replace(rubyElement);
+			} else {
+				for (i = 0; i < nodes.length; i++) {
+					if (i === 0) {
+						nodes[i].replace(rubyElement);
+					} else {
+						nodes[i].insertAfter(nodes[i - 1]);
+					}
+				}
+				lastNode = nodes[nodes.length - 1];
+			}
+
+			cleanupZwsAnchor(lastNode.getNext());
+			cleanupOrphanedZwsAfter(lastNode);
 			refreshHasRubyFlag();
 
 			if (selection) {
 				var range = new CKEDITOR.dom.range(editor.document);
-				if (replacement.type === CKEDITOR.NODE_TEXT) {
-					range.setStart(replacement, replacement.getText().length);
-				} else {
-					range.moveToElementEditEnd(replacement);
-				}
+				range.setStartAfter(lastNode);
 				range.collapse(true);
 				selection.selectRanges([range]);
 			}
 
-			return replacement;
+			return lastNode;
 		}
 
 		/**

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -368,8 +368,27 @@ CKEDITOR.plugins.add('taofurigana', {
 
 			var rbElements = rubyElement.find('rb');
 			var rbElement = rbElements.count() ? rbElements.getItem(0) : null;
-			var baseText = rbElement ? rbElement.getText().replace(zeroWidthSpaceRegex, '') : '';
-			var replacement = new CKEDITOR.dom.text(baseText, editor.document);
+			var replacement;
+
+			if (!rbElement) {
+				replacement = new CKEDITOR.dom.text('', editor.document);
+			} else {
+				// Preserve inline markup inside rb (same approach as cleanupEmptyRubyElements).
+				var rbInnerHtml = rbElement.$.innerHTML.replace(zeroWidthSpaceRegex, '');
+				try {
+					replacement = rbInnerHtml
+						? CKEDITOR.dom.element.createFromHtml(rbInnerHtml, editor.document)
+						: null;
+				} catch (err) {
+					replacement = null;
+				}
+				if (!replacement || replacement.type === CKEDITOR.NODE_TEXT) {
+					replacement = new CKEDITOR.dom.text(
+						rbElement.getText().replace(zeroWidthSpaceRegex, ''),
+						editor.document
+					);
+				}
+			}
 
 			replacement.replace(rubyElement);
 			cleanupZwsAnchor(replacement.getNext());
@@ -378,7 +397,11 @@ CKEDITOR.plugins.add('taofurigana', {
 
 			if (selection) {
 				var range = new CKEDITOR.dom.range(editor.document);
-				range.setStart(replacement, replacement.getText().length);
+				if (replacement.type === CKEDITOR.NODE_TEXT) {
+					range.setStart(replacement, replacement.getText().length);
+				} else {
+					range.moveToElementEditEnd(replacement);
+				}
 				range.collapse(true);
 				selection.selectRanges([range]);
 			}

--- a/plugins/taofurigana/plugin.js
+++ b/plugins/taofurigana/plugin.js
@@ -19,6 +19,11 @@ CKEDITOR.plugins.add('taofurigana', {
 		var keyCodeDelete = 46;
 		var keyCodeBackspace = 8;
 		var keyCodeLeftArrow = 37;
+		// Safety cap for DOM walks that cross <br>/blocks looking for orphan ZWS.
+		var orphanZwsWalkLimit = 50;
+		// Debounce delays for toolbar/command state updates (ms).
+		var commandStateDebounceMs = 50;
+		var toolbarDisableDelayMs = 150;
 		var refreshCommandStateTimer = null;
 		var disableToolbarButtonsTimer = null;
 		var lastFuriganaCommandState = null;
@@ -348,7 +353,7 @@ CKEDITOR.plugins.add('taofurigana', {
 			var rtElement = startNode.getAscendant('rt', true);
 
 			// Do not re-seed ZWS into an empty rt — that causes Backspace to thrash
-			// textLen 0↔1 forever (see INF-530 probe). New rubies get anchors at create time.
+			// textLen 0↔1 forever. New rubies get anchors at create time.
 			if (rtElement && !isEffectivelyEmpty(rtElement)) {
 				ensureRtAnchors(rtElement);
 			}
@@ -667,14 +672,16 @@ CKEDITOR.plugins.add('taofurigana', {
 			var node = getNextNodeCrossingBoundaries(fromNode);
 			var guard = 0;
 
-			while (node && guard < 50) {
+			while (node && guard < orphanZwsWalkLimit) {
 				guard++;
 
+				// Found the orphan ZWS left after ruby was removed / split by Enter.
 				if (isOrphanZwsAnchor(node)) {
 					cleanupZwsAnchor(node);
 					return true;
 				}
 
+				// Skip empty text nodes between the start and the orphan.
 				if (isEmptyTextNode(node)) {
 					node = getNextNodeCrossingBoundaries(node);
 					continue;
@@ -682,6 +689,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 				if (node.type === CKEDITOR.NODE_ELEMENT) {
 					var name = node.getName && node.getName();
+					// Soft line break — keep walking past it.
 					if (name === 'br') {
 						node = getNextNodeCrossingBoundaries(node);
 						continue;
@@ -689,6 +697,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 					var first = node.getFirst && node.getFirst();
 					if (first) {
+						// Orphan ZWS sitting as the first child of the next block/wrapper.
 						if (isOrphanZwsAnchor(first)) {
 							cleanupZwsAnchor(first);
 							return true;
@@ -698,6 +707,7 @@ CKEDITOR.plugins.add('taofurigana', {
 						continue;
 					}
 
+					// Empty element with no children — step to the next sibling/parent boundary.
 					node = getNextNodeCrossingBoundaries(node);
 					continue;
 				}
@@ -710,13 +720,14 @@ CKEDITOR.plugins.add('taofurigana', {
 		}
 
 		/**
-		 * Chrome can delete a whole line when Backspace hits an orphan ZWS left after
+		 * Blink/Chrome can delete a whole line when Backspace hits an orphan ZWS left after
 		 * ruby removal across a line break. Strip that ZWS before native delete runs.
 		 * @param {CKEDITOR.dom.selection} selection
 		 * @param {Number} keyCode
 		 * @returns {Boolean}
 		 */
 		function guardOrphanZwsBackspace(selection, keyCode) {
+			// Only collapsed Backspace — native Delete / ranged selection are left alone.
 			if (keyCode !== keyCodeBackspace || !selection || !selection.isCollapsed()) {
 				return false;
 			}
@@ -732,6 +743,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 			editor.fire('lockSnapshot');
 			try {
+				// Caret is inside an orphan ZWS text node (offset at/near its start).
 				if (
 					startContainer.type === CKEDITOR.NODE_TEXT &&
 					isOrphanZwsAnchor(startContainer) &&
@@ -740,6 +752,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					cleanupZwsAnchor(startContainer);
 					cleaned = true;
 				} else if (startContainer.type === CKEDITOR.NODE_ELEMENT && startOffset === 0) {
+					// Caret at the start of an element whose first child is the orphan ZWS.
 					var child = startContainer.getChild(startOffset);
 					if (isOrphanZwsAnchor(child)) {
 						cleanupZwsAnchor(child);
@@ -755,6 +768,7 @@ CKEDITOR.plugins.add('taofurigana', {
 						startOffset >= startContainer.getText().length;
 					var atEndOfBlock = range.checkEndOfBlock && range.checkEndOfBlock();
 
+					// Caret at end of text or block — orphan may sit after a <br>/next paragraph.
 					if (atEndOfText || atEndOfBlock) {
 						var next = getNextNodeCrossingBoundaries(startContainer);
 						var nextFirst = next && next.type === CKEDITOR.NODE_ELEMENT && next.getFirst ? next.getFirst() : null;
@@ -1086,8 +1100,7 @@ CKEDITOR.plugins.add('taofurigana', {
 
 		/**
 		 * Change command state according to the current selection content.
-		 * Debounced: uncanceled setTimeout(150) on every keyup was stacking and making
-		 * Backspace/Delete feel progressively slower until blur drained the queue.
+		 * Debounced so rapid keyup events do not stack redundant toolbar updates.
 		 * @param {CkEditor} editor - ckEditor instance
 		 * @param {Boolean} [immediate]
 		 */
@@ -1099,7 +1112,7 @@ CKEDITOR.plugins.add('taofurigana', {
 				refreshCommandStateTimer = setTimeout(function () {
 					refreshCommandStateTimer = null;
 					refreshCommandStateNow(editor);
-				}, 50);
+				}, commandStateDebounceMs);
 				return;
 			}
 
@@ -1160,7 +1173,7 @@ CKEDITOR.plugins.add('taofurigana', {
 					statelessButtons.forEach(function (button) {
 						button.setState(CKEDITOR.TRISTATE_OFF);
 					});
-				}, 150);
+				}, toolbarDisableDelayMs);
 			}
 
 			if (!command) {

--- a/scripts/link-to-tao.sh
+++ b/scripts/link-to-tao.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Sync a *built* CKEditor into tao-core's @oat-sa/tao-core-shared-libs for qtiCreator testing.
+#
+# Do NOT symlink the unbuilt ckeditor-dev tree: the web server refuses paths that escape
+# the document root, and TAO expects the built ckeditor.js bundle (taofurigana is compiled in).
+#
+# Workflow:
+#   1. Edit PATH CONFIG below (or export CKEDITOR_DEV / TAO_CORE_VIEWS)
+#   2. cd "$CKEDITOR_DEV/dev/builder" && ./build.sh --unminified
+#   3. ./scripts/link-to-tao.sh sync
+#   4. Hard-refresh backoffice
+#   5. ./scripts/link-to-tao.sh restore   when done
+#
+# For fast plugin iteration without TAO, use samples/taofurigana.html (dev loader, no build).
+set -euo pipefail
+
+# =============================================================================
+# PATH CONFIG — replace the placeholders with real absolute paths on your machine
+# You can also export CKEDITOR_DEV / TAO_CORE_VIEWS in the shell (env wins).
+# =============================================================================
+CKEDITOR_DEV="${CKEDITOR_DEV:-/path/to/ckeditor-dev}"
+TAO_CORE_VIEWS="${TAO_CORE_VIEWS:-/path/to/nextgen-stack/tao/tao/views}"
+# =============================================================================
+
+SHARED_LIBS_CKEDITOR="${TAO_CORE_VIEWS}/node_modules/@oat-sa/tao-core-shared-libs/lib/ckeditor"
+BACKUP_PATH="${SHARED_LIBS_CKEDITOR}.bak-before-link"
+RELEASE_DIR="${CKEDITOR_DEV}/dev/builder/release/ckeditor"
+
+is_placeholder_path() {
+	local value="$1"
+	[[ -z "$value" ]] \
+		|| [[ "$value" == /path/to/* ]] \
+		|| [[ "$value" == *"/path/to/"* ]] \
+		|| [[ "$value" == *__SET_ME__* ]] \
+		|| [[ "$value" == *CHANGE_ME* ]]
+}
+
+print_path_setup_help() {
+	cat <<EOF >&2
+
+Set the paths before running this script.
+
+Option A — edit PATH CONFIG at the top of:
+  $(cd "$(dirname "$0")" && pwd)/$(basename "$0")
+
+Option B — export in your shell for this session:
+  export CKEDITOR_DEV="/absolute/path/to/ckeditor-dev"
+  export TAO_CORE_VIEWS="/absolute/path/to/nextgen-stack/tao/tao/views"
+
+Current values:
+  CKEDITOR_DEV=$CKEDITOR_DEV
+  TAO_CORE_VIEWS=$TAO_CORE_VIEWS
+
+EOF
+}
+
+require_paths_configured() {
+	local ok=1
+
+	if is_placeholder_path "$CKEDITOR_DEV"; then
+		echo "error: CKEDITOR_DEV is still a placeholder (or empty)." >&2
+		ok=0
+	elif [[ ! -d "$CKEDITOR_DEV" ]]; then
+		echo "error: CKEDITOR_DEV does not exist or is not a directory:" >&2
+		echo "  $CKEDITOR_DEV" >&2
+		ok=0
+	elif [[ ! -f "$CKEDITOR_DEV/ckeditor.js" && ! -d "$CKEDITOR_DEV/plugins/taofurigana" ]]; then
+		echo "error: CKEDITOR_DEV does not look like the ckeditor-dev repo:" >&2
+		echo "  $CKEDITOR_DEV" >&2
+		ok=0
+	fi
+
+	if is_placeholder_path "$TAO_CORE_VIEWS"; then
+		echo "error: TAO_CORE_VIEWS is still a placeholder (or empty)." >&2
+		ok=0
+	elif [[ ! -d "$TAO_CORE_VIEWS" ]]; then
+		echo "error: TAO_CORE_VIEWS does not exist or is not a directory:" >&2
+		echo "  $TAO_CORE_VIEWS" >&2
+		ok=0
+	fi
+
+	if [[ "$ok" -ne 1 ]]; then
+		print_path_setup_help
+		exit 1
+	fi
+}
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") <sync|restore|status>
+
+  sync     Copy built release/ckeditor into shared-libs (backs up vendor copy once)
+  restore  Restore the backed-up vendor copy
+  status   Show current state
+
+Paths (edit PATH CONFIG at top of this script, or export before running):
+  CKEDITOR_DEV=$CKEDITOR_DEV
+  TAO_CORE_VIEWS=$TAO_CORE_VIEWS
+EOF
+}
+
+require_shared_path() {
+	require_paths_configured
+
+	if [[ ! -e "$SHARED_LIBS_CKEDITOR" && ! -L "$SHARED_LIBS_CKEDITOR" && ! -e "$BACKUP_PATH" ]]; then
+		echo "error: shared-libs ckeditor path not found:" >&2
+		echo "  $SHARED_LIBS_CKEDITOR" >&2
+		echo "Install @oat-sa/tao-core-shared-libs under tao/tao/views first." >&2
+		echo "Also verify TAO_CORE_VIEWS points at .../tao/tao/views" >&2
+		print_path_setup_help
+		exit 1
+	fi
+}
+
+cmd_status() {
+	require_shared_path
+	echo "CKEDITOR_DEV=$CKEDITOR_DEV"
+	echo "TAO_CORE_VIEWS=$TAO_CORE_VIEWS"
+	if [[ -L "$SHARED_LIBS_CKEDITOR" ]]; then
+		echo "BROKEN SETUP: symlink -> $(readlink "$SHARED_LIBS_CKEDITOR")"
+		echo "Run: $(basename "$0") restore"
+	elif [[ -d "$SHARED_LIBS_CKEDITOR" ]]; then
+		local size
+		size="$(wc -c <"$SHARED_LIBS_CKEDITOR/ckeditor.js" 2>/dev/null | tr -d ' ')"
+		if [[ -n "$size" && "$size" -lt 50000 ]]; then
+			echo "WARNING: ckeditor.js is only ${size} bytes (looks like unbuilt loader). Run restore or sync a build."
+		else
+			echo "Active copy at $SHARED_LIBS_CKEDITOR (ckeditor.js ${size:-?} bytes)"
+		fi
+	else
+		echo "Missing: $SHARED_LIBS_CKEDITOR"
+	fi
+	if [[ -e "$BACKUP_PATH" || -L "$BACKUP_PATH" ]]; then
+		echo "Backup present: $BACKUP_PATH"
+	fi
+	if [[ -d "$RELEASE_DIR" ]]; then
+		echo "Build release present: $RELEASE_DIR"
+	else
+		echo "No build release yet — run: cd $CKEDITOR_DEV/dev/builder && ./build.sh --unminified"
+	fi
+}
+
+cmd_sync() {
+	require_shared_path
+
+	if [[ -L "$SHARED_LIBS_CKEDITOR" ]]; then
+		echo "error: lib/ckeditor is a symlink (unsupported). Run: $(basename "$0") restore" >&2
+		exit 1
+	fi
+
+	if [[ ! -f "$RELEASE_DIR/ckeditor.js" ]]; then
+		echo "error: no built release at $RELEASE_DIR" >&2
+		echo "Build first: cd $CKEDITOR_DEV/dev/builder && ./build.sh --unminified" >&2
+		exit 1
+	fi
+
+	local release_size
+	release_size="$(wc -c <"$RELEASE_DIR/ckeditor.js" | tr -d ' ')"
+	if [[ "$release_size" -lt 50000 ]]; then
+		echo "error: release ckeditor.js looks too small (${release_size} bytes) — not a real build" >&2
+		exit 1
+	fi
+
+	if [[ ! -e "$BACKUP_PATH" ]]; then
+		echo "Backing up vendor copy to $BACKUP_PATH"
+		cp -a "$SHARED_LIBS_CKEDITOR" "$BACKUP_PATH"
+	else
+		echo "Backup already exists — leaving it untouched"
+	fi
+
+	echo "Syncing $RELEASE_DIR -> $SHARED_LIBS_CKEDITOR"
+	rsync -a --delete \
+		--exclude '.git' \
+		--exclude '.bender' \
+		--exclude 'node_modules' \
+		"$RELEASE_DIR"/ "$SHARED_LIBS_CKEDITOR"/
+
+	echo "Done. Hard-refresh backoffice. Restore with: $(basename "$0") restore"
+}
+
+cmd_restore() {
+	require_shared_path
+
+	if [[ -L "$SHARED_LIBS_CKEDITOR" ]]; then
+		if [[ ! -e "$BACKUP_PATH" ]]; then
+			echo "error: symlink present but no backup at $BACKUP_PATH" >&2
+			exit 1
+		fi
+		rm "$SHARED_LIBS_CKEDITOR"
+		mv "$BACKUP_PATH" "$SHARED_LIBS_CKEDITOR"
+		echo "Removed symlink and restored vendor copy"
+		exit 0
+	fi
+
+	if [[ ! -e "$BACKUP_PATH" ]]; then
+		echo "No backup at $BACKUP_PATH — nothing to restore."
+		exit 0
+	fi
+
+	rm -rf "$SHARED_LIBS_CKEDITOR"
+	mv "$BACKUP_PATH" "$SHARED_LIBS_CKEDITOR"
+	echo "Restored vendor copy to $SHARED_LIBS_CKEDITOR"
+}
+
+case "${1:-}" in
+	sync) cmd_sync ;;
+	restore|unlink) cmd_restore ;;
+	link)
+		echo "error: 'link' (symlink) was removed — it breaks RequireJS (symlink escapes web root)." >&2
+		echo "Use: $(basename "$0") sync   after building with ./build.sh --unminified" >&2
+		exit 1
+		;;
+	status) cmd_status ;;
+	*) usage; exit 1 ;;
+esac

--- a/scripts/link-to-tao.sh
+++ b/scripts/link-to-tao.sh
@@ -120,8 +120,11 @@ cmd_status() {
 		echo "BROKEN SETUP: symlink -> $(readlink "$SHARED_LIBS_CKEDITOR")"
 		echo "Run: $(basename "$0") restore"
 	elif [[ -d "$SHARED_LIBS_CKEDITOR" ]]; then
-		local size
-		size="$(wc -c <"$SHARED_LIBS_CKEDITOR/ckeditor.js" 2>/dev/null | tr -d ' ')"
+		local size=""
+		local ckeditor_js="$SHARED_LIBS_CKEDITOR/ckeditor.js"
+		if [[ -f "$ckeditor_js" ]]; then
+			size="$(wc -c <"$ckeditor_js" | tr -d ' ')"
+		fi
 		if [[ -n "$size" && "$size" -lt 50000 ]]; then
 			echo "WARNING: ckeditor.js is only ${size} bytes (looks like unbuilt loader). Run restore or sync a build."
 		else

--- a/scripts/link-to-tao.sh
+++ b/scripts/link-to-tao.sh
@@ -120,15 +120,17 @@ cmd_status() {
 		echo "BROKEN SETUP: symlink -> $(readlink "$SHARED_LIBS_CKEDITOR")"
 		echo "Run: $(basename "$0") restore"
 	elif [[ -d "$SHARED_LIBS_CKEDITOR" ]]; then
-		local size=""
+		local size
 		local ckeditor_js="$SHARED_LIBS_CKEDITOR/ckeditor.js"
-		if [[ -f "$ckeditor_js" ]]; then
-			size="$(wc -c <"$ckeditor_js" | tr -d ' ')"
+		if [[ ! -f "$ckeditor_js" ]]; then
+			echo "error: ckeditor.js not found at $ckeditor_js" >&2
+			return 1
 		fi
-		if [[ -n "$size" && "$size" -lt 50000 ]]; then
+		size="$(wc -c <"$ckeditor_js" | tr -d ' ')"
+		if [[ "$size" -lt 50000 ]]; then
 			echo "WARNING: ckeditor.js is only ${size} bytes (looks like unbuilt loader). Run restore or sync a build."
 		else
-			echo "Active copy at $SHARED_LIBS_CKEDITOR (ckeditor.js ${size:-?} bytes)"
+			echo "Active copy at $SHARED_LIBS_CKEDITOR (ckeditor.js ${size} bytes)"
 		fi
 	else
 		echo "Missing: $SHARED_LIBS_CKEDITOR"


### PR DESCRIPTION
Ticket : https://oat-sa.atlassian.net/browse/INF-530
## Summary
- Fixes [INF-530](https://oat-sa.atlassian.net/browse/INF-530): after applying ruby, Enter, then removing ruby, Backspace near the orphan ZWS no longer deletes the whole line.
- Improves taofurigana Backspace/Delete handling around ruby (orphan ZWS cleanup, empty `rt` unwrap, caret placement).
- Adds `scripts/link-to-tao.sh` for syncing a built CKEditor into tao-core shared-libs (paths must be configured; placeholders fail loudly).

## Test plan
- [x] Reproduce INF-530 steps in qtiCreator with a built+synced CKEditor: apply ruby at end of line → Enter → remove ruby → Backspace near the break — only one character/ZWS should be removed, not the whole line
- [x] Apply/remove ruby, Backspace into `rt` / after ruby — caret and deletion behave as expected
- [x] Empty `rt` unwraps cleanly without sluggish thrashing
- [x] `./scripts/link-to-tao.sh status` without configured paths prints setup help and exits non-zero

## Video

https://github.com/user-attachments/assets/feaf3dda-0496-4405-9d36-04671004f51d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved furigana/ruby editing reliability, including Backspace/Delete unwrapping for empty readings, tighter caret normalization, and cleanup of leftover caret/anchor artifacts.
  * Enhanced selection/change handling so command and toolbar state stays synchronized more consistently.

* **New Features**
  * Added a local CKEditor bundle sync/restore/status workflow to streamline qtiCreator testing with unminified builds.

* **Documentation**
  * Expanded CK Playground setup with step-by-step furigana/ruby guidance and the updated testing workflow.

* **Chores**
  * Updated the furigana plugin’s English language registration key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[INF-530]: https://oat-sa.atlassian.net/browse/INF-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ